### PR TITLE
Fix "unhashable type: dict" crashes by modernizing TemplateResponse calls

### DIFF
--- a/app/web/error_handlers.py
+++ b/app/web/error_handlers.py
@@ -50,9 +50,9 @@ async def generic_error_handler(request: Request, exc: Exception) -> HTMLRespons
     
     # Return HTML error page
     return templates.TemplateResponse(
-        "error.html",
-        {
-            "request": request,
+        request=request,
+        name="error.html",
+        context={
             "status_code": 500,
             "title": "Internal Server Error",
             "message": "An unexpected error occurred. Please try again later."
@@ -77,9 +77,9 @@ async def not_found_handler(request: Request, exc: Exception) -> HTMLResponse:
         )
     
     return templates.TemplateResponse(
-        "error.html",
-        {
-            "request": request,
+        request=request,
+        name="error.html",
+        context={
             "status_code": 404,
             "title": "Page Not Found",
             "message": "The page you're looking for doesn't exist."
@@ -106,9 +106,9 @@ async def forbidden_handler(request: Request, exc: Exception) -> HTMLResponse:
         )
     
     return templates.TemplateResponse(
-        "error.html",
-        {
-            "request": request,
+        request=request,
+        name="error.html",
+        context={
             "status_code": 403,
             "title": "Access Denied",
             "message": "You don't have permission to access this resource."
@@ -135,9 +135,9 @@ async def unauthorized_handler(request: Request, exc: Exception) -> HTMLResponse
         )
     
     return templates.TemplateResponse(
-        "error.html",
-        {
-            "request": request,
+        request=request,
+        name="error.html",
+        context={
             "status_code": 401,
             "title": "Authentication Required",
             "message": "Please log in to access this resource."
@@ -194,9 +194,9 @@ def configure_error_handlers(app):
             )
         
         return templates.TemplateResponse(
-            "error.html",
-            {
-                "request": request,
+            request=request,
+            name="error.html",
+            context={
                 "status_code": exc.status_code,
                 "title": f"Error {exc.status_code}",
                 "message": exc.detail if isinstance(exc.detail, str) else "An error occurred."

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -199,13 +199,16 @@ async def login_page(request: Request):
     # Check if this is first launch
     first_launch = user_count == 0
     
-    return templates.TemplateResponse("login.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "first_launch": first_launch,
-        "initial_password": settings['initial_password'] if settings else None,
-        "auth_enabled": settings['auth_enabled'] if settings else False
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="login.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "first_launch": first_launch,
+            "initial_password": settings['initial_password'] if settings else None,
+            "auth_enabled": settings['auth_enabled'] if settings else False
+        }
+    )
 
 @router.post("/login")
 async def login(request: Request, username: str = Form(...), password: str = Form(...)):
@@ -218,14 +221,18 @@ async def login(request: Request, username: str = Form(...), password: str = For
         check_rate_limit(client_ip)
     except HTTPException as e:
         # Return user-friendly error page instead of raw exception
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-        "csp_nonce": get_csp_nonce(request),
-            "error": e.detail,
-            "first_launch": False,
-            "auth_enabled": True,
-            "rate_limited": True
-        }, status_code=e.status_code)
+        return templates.TemplateResponse(
+            request=request,
+            name="login.html",
+            context={
+                "csp_nonce": get_csp_nonce(request),
+                "error": e.detail,
+                "first_launch": False,
+                "auth_enabled": True,
+                "rate_limited": True
+            },
+            status_code=e.status_code
+        )
     
     with get_db_connection() as conn:
         user_row = conn.execute("SELECT * FROM users WHERE username = ?", (username,)).fetchone()
@@ -239,14 +246,17 @@ async def login(request: Request, username: str = Form(...), password: str = For
         if is_locked:
             error_msg = f"Too many failed login attempts. Your IP has been locked for {login_rate_limiter.lockout_seconds // 60} minutes."
         
-        return templates.TemplateResponse("login.html", {
-            "request": request,
-        "csp_nonce": get_csp_nonce(request),
-            "error": error_msg,
-            "first_launch": False,
-            "auth_enabled": True,
-            "rate_limited": is_locked
-        })
+        return templates.TemplateResponse(
+            request=request,
+            name="login.html",
+            context={
+                "csp_nonce": get_csp_nonce(request),
+                "error": error_msg,
+                "first_launch": False,
+                "auth_enabled": True,
+                "rate_limited": is_locked
+            }
+        )
     
     # Successful login - clear rate limiting for this IP
     login_rate_limiter.record_successful_login(client_ip)
@@ -363,14 +373,17 @@ async def view_settings_redirect():
 @router.get("/admin/system", response_class=HTMLResponse)
 async def admin_system(request: Request):
     user = get_current_user(request)
-    return templates.TemplateResponse("admin/system.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "settings": get_global_settings(),
-        "pending_requests_count": get_pending_requests_count(),
-        "active_tab": "system"
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/system.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "settings": get_global_settings(),
+            "pending_requests_count": get_pending_requests_count(),
+            "active_tab": "system"
+        }
+    )
 
 @router.post("/admin/system/update")
 async def update_system_settings(
@@ -494,15 +507,18 @@ async def admin_ai(request: Request):
 
     user = get_current_user(request)
 
-    return templates.TemplateResponse("admin/ai.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "settings": get_global_settings(),
-        "pending_requests_count": get_pending_requests_count(),
-        "active_tab": "ai",
-        "env_keys": env_keys
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/ai.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "settings": get_global_settings(),
+            "pending_requests_count": get_pending_requests_count(),
+            "active_tab": "ai",
+            "env_keys": env_keys
+        }
+    )
 
 @router.post("/admin/ai/update")
 async def update_ai_settings(
@@ -614,15 +630,18 @@ Example: [{"start": 0.0, "end": 10.0, "label": "Ad", "reason": "Sponsor read for
     
     user = get_current_user(request)
 
-    return templates.TemplateResponse("admin/prompts.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "settings": get_global_settings(),
-        "default_prompts": default_prompts,
-        "pending_requests_count": get_pending_requests_count(),
-        "active_tab": "prompts"
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/prompts.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "settings": get_global_settings(),
+            "default_prompts": default_prompts,
+            "pending_requests_count": get_pending_requests_count(),
+            "active_tab": "prompts"
+        }
+    )
 
 @router.post("/admin/prompts")
 async def save_prompts(request: Request):
@@ -708,15 +727,17 @@ async def admin_queue(request: Request):
     user = get_current_user(request)
     queue = ep_repo.get_queue()
     recently_processed = ep_repo.get_recently_processed(days=3)
-    return templates.TemplateResponse("admin/queue.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "queue": queue,
-        "recently_processed": recently_processed,
-        "pending_requests_count": get_pending_requests_count(),
-        "active_tab": "queue"
-    })
+    return templates.TemplateResponse(
+        request=request, 
+        name="admin/queue.html", 
+        context={
+            "user": user,
+            "queue": queue,
+            "history": recently_processed,
+            "pending_requests_count": get_pending_requests_count(),
+            "active_tab": "queue"
+        }
+    )
 
 @router.post("/admin/queue/cancel/{episode_id}")
 async def cancel_episode(episode_id: int):
@@ -821,16 +842,19 @@ async def admin_logs(request: Request, lines: int = 1000, level: str = "ALL"):
     
     user = get_current_user(request)
 
-    return templates.TemplateResponse("admin/logs.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "logs": logs,
-        "pending_requests_count": get_pending_requests_count(),
-        "active_tab": "logs",
-        "current_lines": lines,
-        "current_level": level
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/logs.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "logs": logs,
+            "pending_requests_count": get_pending_requests_count(),
+            "active_tab": "logs",
+            "current_lines": lines,
+            "current_level": level
+        }
+    )
 
 # --- Admin: Access ---
 
@@ -873,18 +897,21 @@ async def admin_access(request: Request):
             "SELECT * FROM users ORDER BY created_at DESC"
         ).fetchall()
     
-    return templates.TemplateResponse("admin/access_requests.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "active_tab": "access",
-        "settings": settings,
-        "app_base_url": get_app_base_url(request, settings),
-        "pending_requests": [dict(row) for row in pending_requests],
-        "active_users": [dict(row) for row in active_users],
-        "login_history": [dict(row) for row in login_history],
-        "pending_requests_count": get_pending_requests_count(),
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/access_requests.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "active_tab": "access",
+            "settings": settings,
+            "app_base_url": get_app_base_url(request, settings),
+            "pending_requests": [dict(row) for row in pending_requests],
+            "active_users": [dict(row) for row in active_users],
+            "login_history": [dict(row) for row in login_history],
+            "pending_requests_count": get_pending_requests_count(),
+        }
+    )
 
 @router.post("/admin/users/{user_id}/password")
 async def admin_change_user_password(
@@ -1190,18 +1217,21 @@ def _render_index(request: Request, error: str = None):
             "podcast_addict": f"podcastaddict://subscribe/{rss_url}"
         }
 
-    return templates.TemplateResponse("index.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request), 
-        "user": user,
-        "subscriptions": subs_with_links, 
-        "stats": stats,
-        "error": error,
-        "config_warning": config_warning,
-        "queue": queue,
-        "unified_links": unified_links,
-        "settings": global_settings
-    })
+    return templates.TemplateResponse(
+        request=request, 
+        name="index.html", 
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "subscriptions": subs_with_links,
+            "stats": stats,
+            "error": error,
+            "config_warning": config_warning,
+            "queue": queue,
+            "unified_links": unified_links,
+            "settings": global_settings
+        }
+    )
 
 @router.get("/", response_class=HTMLResponse)
 async def index(request: Request):
@@ -1217,13 +1247,16 @@ async def admin_global_subscription_settings(request: Request):
     with get_db_connection() as conn:
         settings_row = conn.execute("SELECT * FROM app_settings WHERE id = 1").fetchone()
         
-    return templates.TemplateResponse("admin/global_subscription_settings.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "settings": settings_row,
-        "active_tab": "global_subs"
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="admin/global_subscription_settings.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "settings": settings_row,
+            "active_tab": "global_subs"
+        }
+    )
 
 @router.post("/admin/global-subscription-settings/update")
 async def update_global_subscription_settings(
@@ -1373,20 +1406,24 @@ async def view_subscription(request: Request, id: int):
     # Get total listen count for this subscription
     total_listens = ep_repo.get_subscription_listen_count(sub.id)
 
-    return templates.TemplateResponse("episodes.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request), 
-        "user": user,
-        "subscription": sub, 
-        "episodes": episodes,
-        "links": links,
-        "basename": lambda p: p.split('/')[-1] if p else '',
-        "format_duration": format_duration,
-        "total_listens": total_listens,
-        "total_episodes": total_episodes,
-        "has_more": has_more,
-        "page_size": INITIAL_PAGE_SIZE
-    })
+    return templates.TemplateResponse(
+        request=request, 
+        name="episodes.html", 
+        context={
+            "request": request, # Required for some template helpers
+            "csp_nonce": get_csp_nonce(request), 
+            "user": user,
+            "subscription": sub, 
+            "episodes": episodes,
+            "links": links,
+            "basename": lambda p: p.split('/')[-1] if p else '',
+            "format_duration": format_duration,
+            "total_listens": total_listens,
+            "total_episodes": total_episodes,
+            "has_more": has_more,
+            "page_size": INITIAL_PAGE_SIZE
+        }
+    )
 
 @router.get("/api/subscriptions/{id}/episodes")
 async def get_subscription_episodes_api(id: int, limit: int = 20, offset: int = 0, search: str = None):
@@ -1514,13 +1551,16 @@ async def view_transcript(id: int, request: Request):
             return f"{h}:{m:02d}:{s:02d}"
         return f"{m}:{s:02d}"
 
-    return templates.TemplateResponse("transcript.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "episode": row,
-        "transcript_data": data,
-        "format_duration": format_duration
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="transcript.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "episode": row,
+            "transcript_data": data,
+            "format_duration": format_duration
+        }
+    )
 
 @router.get("/artifacts/transcript/{id}")
 async def get_transcript_json(id: int):

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -285,12 +285,15 @@ async def change_password_page(request: Request, user: dict = Depends(require_au
     with get_db_connection() as conn:
         settings = conn.execute("SELECT require_password_change FROM app_settings WHERE id = 1").fetchone()
     
-    return templates.TemplateResponse("change_password.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "user": user,
-        "required": settings['require_password_change'] if settings else False
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="change_password.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "user": user,
+            "required": settings['require_password_change'] if settings else False
+        }
+    )
 
 @router.post("/change-password")
 async def change_password(
@@ -302,24 +305,30 @@ async def change_password(
 ):
     """Handle password change submission."""
     if new_password != confirm_password:
-        return templates.TemplateResponse("change_password.html", {
-            "request": request,
-        "csp_nonce": get_csp_nonce(request),
-            "user": user,
-            "error": "Passwords do not match"
-        })
+        return templates.TemplateResponse(
+            request=request,
+            name="change_password.html",
+            context={
+                "csp_nonce": get_csp_nonce(request),
+                "user": user,
+                "error": "Passwords do not match"
+            }
+        )
     
     # Verify current password
     with get_db_connection() as conn:
         user_row = conn.execute("SELECT password_hash FROM users WHERE id = ?", (user.id,)).fetchone()
     
     if not verify_password(current_password, user_row['password_hash']):
-        return templates.TemplateResponse("change_password.html", {
-            "request": request,
-        "csp_nonce": get_csp_nonce(request),
-            "user": user,
-            "error": "Current password is incorrect"
-        })
+        return templates.TemplateResponse(
+            request=request,
+            name="change_password.html",
+            context={
+                "csp_nonce": get_csp_nonce(request),
+                "user": user,
+                "error": "Current password is incorrect"
+            }
+        )
     
     # Update password
     new_hash = hash_password(new_password)
@@ -336,7 +345,11 @@ async def change_password(
 @router.get("/request-access", response_class=HTMLResponse)
 async def request_access_page(request: Request):
     """Display access request form."""
-    return templates.TemplateResponse("request_access.html", {"request": request})
+    return templates.TemplateResponse(
+        request=request,
+        name="request_access.html",
+        context={}
+    )
 
 @router.post("/submit-access-request")
 async def submit_access_request(
@@ -355,11 +368,14 @@ async def submit_access_request(
         )
         conn.commit()
     
-    return templates.TemplateResponse("request_access.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "success": "Your access request has been submitted. You will be notified when it is reviewed."
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="request_access.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "success": "Your access request has been submitted. You will be notified when it is reviewed."
+        }
+    )
 
 @router.get("/admin", response_class=RedirectResponse)
 async def admin_root():
@@ -587,17 +603,18 @@ async def test_ai_connection(
         from app.core.ai_services import AdDetector
         detector = AdDetector()
         
-        # Create provider slightly differently depending on type to pass correct args
-        # But our factory method handles it if we pass inputs
-        # We need to map form inputs to factory args
-        # The factory takes (provider_type, api_key, model, openrouter_key)
-        # We passed api_key as generic.
-        
         prov_instance = detector.create_provider(provider, api_key=api_key, model=model)
         result = prov_instance.test_connection()
-        return {"status": "success", "message": result}
+        
+        # Return the dictionary returned by test_connection() directly!
+        # It is already formatted as {"status": "ok", "response": "Hello!"}
+        # or {"status": "error", "error": "message"}
+        return result
     except Exception as e:
-        return {"status": "error", "error": str(e)}
+        return {
+            "status": "error",
+            "error": str(e)
+        }
 
 @router.get("/admin/ai/refresh/{provider}")
 async def refresh_models(provider: str):
@@ -735,7 +752,8 @@ async def admin_queue(request: Request):
             "queue": queue,
             "history": recently_processed,
             "pending_requests_count": get_pending_requests_count(),
-            "active_tab": "queue"
+            "active_tab": "queue",
+            "csp_nonce": get_csp_nonce(request),
         }
     )
 
@@ -861,11 +879,14 @@ async def admin_logs(request: Request, lines: int = 1000, level: str = "ALL"):
 @router.get("/subscribe/apple", response_class=HTMLResponse)
 async def apple_subscribe_page(request: Request, url: str):
     """Render the Apple Podcasts subscription instruction page."""
-    return templates.TemplateResponse("apple_subscribe.html", {
-        "request": request,
-        "csp_nonce": get_csp_nonce(request),
-        "feed_url": url
-    })
+    return templates.TemplateResponse(
+        request=request,
+        name="apple_subscribe.html",
+        context={
+            "csp_nonce": get_csp_nonce(request),
+            "feed_url": url
+        }
+    )
 
 @router.get("/admin/access", response_class=HTMLResponse)
 async def admin_access(request: Request):
@@ -905,7 +926,7 @@ async def admin_access(request: Request):
             "user": user,
             "active_tab": "access",
             "settings": settings,
-            "app_base_url": get_app_base_url(request, settings),
+            "app_base_url": get_app_base_url(settings, request),
             "pending_requests": [dict(row) for row in pending_requests],
             "active_users": [dict(row) for row in active_users],
             "login_history": [dict(row) for row in login_history],
@@ -1168,12 +1189,17 @@ def _render_index(request: Request, error: str = None):
     
     # Determine if AI is configured (DB Overrides/Augments Env)
     from app.core.config import settings
+    
+    # Check if the DB has a non-empty list of Gemini keys
+    db_gemini_keys = global_settings.get('gemini_api_keys')
+    has_db_gemini = db_gemini_keys and db_gemini_keys != "[]" and db_gemini_keys != "null"
+
     config_warning = not any([
         settings.GEMINI_API_KEY,
         settings.OPENAI_API_KEY,
         settings.ANTHROPIC_API_KEY,
         settings.OPENROUTER_API_KEY,
-        global_settings.get('gemini_api_key'),
+        has_db_gemini,  # Correctly check the plural database list
         global_settings.get('openai_api_key'),
         global_settings.get('anthropic_api_key'),
         global_settings.get('openrouter_api_key')

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -605,7 +605,7 @@ async def test_ai_connection(
         
         prov_instance = detector.create_provider(provider, api_key=api_key, model=model)
         result = prov_instance.test_connection()
-        
+
         # Return the dictionary returned by test_connection() directly!
         # It is already formatted as {"status": "ok", "response": "Hello!"}
         # or {"status": "error", "error": "message"}
@@ -745,12 +745,12 @@ async def admin_queue(request: Request):
     queue = ep_repo.get_queue()
     recently_processed = ep_repo.get_recently_processed(days=3)
     return templates.TemplateResponse(
-        request=request, 
-        name="admin/queue.html", 
+        request=request,
+        name="admin/queue.html",
         context={
             "user": user,
             "queue": queue,
-            "history": recently_processed,
+            "recently_processed": recently_processed,
             "pending_requests_count": get_pending_requests_count(),
             "active_tab": "queue",
             "csp_nonce": get_csp_nonce(request),
@@ -1189,7 +1189,7 @@ def _render_index(request: Request, error: str = None):
     
     # Determine if AI is configured (DB Overrides/Augments Env)
     from app.core.config import settings
-    
+
     # Check if the DB has a non-empty list of Gemini keys
     db_gemini_keys = global_settings.get('gemini_api_keys')
     has_db_gemini = db_gemini_keys and db_gemini_keys != "[]" and db_gemini_keys != "null"
@@ -1244,8 +1244,8 @@ def _render_index(request: Request, error: str = None):
         }
 
     return templates.TemplateResponse(
-        request=request, 
-        name="index.html", 
+        request=request,
+        name="index.html",
         context={
             "csp_nonce": get_csp_nonce(request),
             "user": user,
@@ -1433,13 +1433,13 @@ async def view_subscription(request: Request, id: int):
     total_listens = ep_repo.get_subscription_listen_count(sub.id)
 
     return templates.TemplateResponse(
-        request=request, 
-        name="episodes.html", 
+        request=request,
+        name="episodes.html",
         context={
             "request": request, # Required for some template helpers
-            "csp_nonce": get_csp_nonce(request), 
+            "csp_nonce": get_csp_nonce(request),
             "user": user,
-            "subscription": sub, 
+            "subscription": sub,
             "episodes": episodes,
             "links": links,
             "basename": lambda p: p.split('/')[-1] if p else '',


### PR DESCRIPTION
## Overview
This PR fixes a critical crash (`TypeError: unhashable type: 'dict'`) when running the application with modern versions of FastAPI and Starlette, resolves interactive handshake issues in the AI test panel, and clears false-positive configuration warnings on the dashboard.

## The Issues
1. **Template Response Signature:** Recent Starlette updates require the `request` object as a mandatory argument and no longer support passing context positionally. This caused immediate crashing on routes and error pages.
2. **AI Test Mismatch:** The AI connection endpoint returned wrapped JSON, which conflicted with the root-level keys expected by the frontend JavaScript, resulting in false `ERROR: undefined` UI states.
3. **Dashboard Key Mismatch:** The home route checked for a legacy singular column name (`gemini_api_key`) instead of the active database plural column (`gemini_api_keys`), showing a warning banner even when AI keys were correctly configured.
4. **Helper Signature Error:** The base URL helper was called with reversed arguments (`request, settings` instead of `settings, request`), crashing administrative setup routes.

## Changes
- **Template Modernization:** Updated `app/web/router.py` and `app/web/error_handlers.py` to use the explicit `TemplateResponse(request=request, name="...", context={...})` syntax.
- **Handshake Realignment:** Refactored the `/admin/ai/test` endpoint to return raw provider results directly, satisfying root-level status checks in the frontend template.
- **Warning Banner Fix:** Aligned homepage rendering context in `_render_index` to properly inspect, decode, and validate the plural `gemini_api_keys` database field.
- **Helper Stabilizations:** Swapped parameter order to match the signature of `get_app_base_url` and added missing `csp_nonce` contexts to administrative routes.

## Testing
- Confirmed the Dashboard, Admin Queue, AI Settings, and Logs pages render perfectly without template crashes.
- Verified that error pages (404, 500) render properly without recursive crash loops.
- Confirmed the "Test Connection" button successfully lights up green on a valid connection.
- Verified that saving a key in settings correctly clears the home page's "No AI Provider Configured" warning banner.