### PR TITLE
Better handling of invalid length

### DIFF
--- a/app/core/feed.py
+++ b/app/core/feed.py
@@ -41,21 +41,21 @@ class FeedManager:
         d = feedparser.parse(FeedManager._fetch_feed(url))
         if d.bozo:
             raise ValueError(f"Invalid feed: {d.bozo_exception}")
-        
+
         if not hasattr(d, 'feed') or not hasattr(d.feed, 'title'):
-             raise ValueError("Feed has no title")
-             
+            raise ValueError("Feed has no title")
+
         title = d.feed.title
         slug = slugify(title)
-        
+
         description = d.feed.get('summary', d.feed.get('description', ''))
-        
+
         image_url = None
         if hasattr(d.feed, 'image') and hasattr(d.feed.image, 'href'):
             image_url = d.feed.image.href
         elif hasattr(d.feed, 'itunes_image') and hasattr(d.feed.itunes_image, 'href'):
-             image_url = d.feed.itunes_image.href
-             
+            image_url = d.feed.itunes_image.href
+
         return title, slug, image_url, description
 
     @staticmethod
@@ -63,17 +63,17 @@ class FeedManager:
         """Parse all episodes from feed."""
         d = feedparser.parse(FeedManager._fetch_feed(url))
         episodes = []
-        
+
         for entry in d.entries:
             # Find audio enclosure
             enclosure = next((l for l in entry.get('links', []) if l.get('type', '').startswith('audio/')), None)
             if not enclosure:
                 continue
-                
+
             pub_date = None
             if hasattr(entry, 'published_parsed'):
                 pub_date = datetime.fromtimestamp(mktime(entry.published_parsed))
-            
+
             description = entry.get('summary', entry.get('description', ''))
 
             # Parse duration
@@ -101,7 +101,7 @@ class FeedManager:
                 'original_url': enclosure.href,
                 'duration': duration,
                 'description': description,
-                'file_size': int(enclosure.length) if hasattr(enclosure, 'length') and enclosure.length else 0
+                'file_size': int(enclosure.length) if hasattr(enclosure, 'length') and enclosure.length and str(enclosure.length).isdigit() else 0
             })
-            
+
         return episodes

--- a/tests/test_data/problematic_feed.xml
+++ b/tests/test_data/problematic_feed.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+    <channel>
+        <atom:link href="https://feed.testing.org/feed/rss.aspx?feed=test" rel="self" type="application/rss+xml" />
+        <image>
+            <url>https://www.test.org/images/test.png</url>
+            <title>The Test</title>
+            <link>https://www.test.org</link>
+            <width>144</width>
+            <height>144</height>
+        </image>
+        <title>The Test</title>
+        <description>Test failing podcast</description>
+        <link>https://www.test.org/podcast/test</link>
+        <docs>https://blogs.law.harvard.edu/tech/rss</docs>
+        <language>en-us</language>
+        <managingEditor>test@test.org</managingEditor>
+        <lastBuildDate>Wed, 19 Oct 2016 11:22:00 -0400</lastBuildDate>
+        <pubDate>Wed, 19 Oct 2016 17:02:29 -0400</pubDate>
+        <ttl>60</ttl>
+        <webMaster>test@test.org</webMaster>
+        <itunes:author>Tester Test</itunes:author>
+        <itunes:new-feed-url>https://feed.test.org/feed/rss.aspx?feed=test</itunes:new-feed-url>
+        <itunes:owner>
+            <itunes:name>Tester Test</itunes:name>
+            <itunes:email>test@test.org</itunes:email>
+        </itunes:owner>
+        <itunes:image href="https://www.test.org/images/test.png" />
+        <itunes:keywords>test</itunes:keywords>
+        <itunes:subtitle>Test</itunes:subtitle>
+        <itunes:summary>Test</itunes:summary>
+        <itunes:category text="Science" />
+        <itunes:explicit>no</itunes:explicit>
+        <item>
+            <title>Test 1 OK</title>
+            <description>Regular working item</description>
+            <enclosure url="https://traffic.libsyn.com/secure/test/test-01.mp3" length="129939533" type="audio/mpeg" />
+            <pubDate>Sat, 20 Jun 2026 10:00:00 -0400</pubDate>
+            <guid>https://www.test.org/podcast/test/1</guid>
+        </item>
+        <item>
+            <title>Test 2 Bad length</title>
+            <description>Broken Item, length contains a string</description>
+            <enclosure url="https://traffic.libsyn.com/secure/test/test-02.mp3" length="https://traffic.libsyn.com/secure/test/test" type="audio/mpeg" />
+            <pubDate>Sat, 21 Mar 2026 10:00:00 -0400</pubDate>
+            <guid>https://www.test.org/podcast/test/2</guid>
+        </item>
+    </channel>
+</rss>

--- a/tests/test_feed_manager.py
+++ b/tests/test_feed_manager.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.core.config import settings
 from app.core.feed import FeedManager
+from pathlib import Path
 
 
 class FakeStreamResponse:
@@ -107,3 +108,38 @@ def test_parse_feed_and_episodes_from_sample_rss(monkeypatch):
         }
     ]
     assert episodes[0]["pub_date"].year == 2024
+
+
+def test_parse_problematic_feed_reproduces_issue(monkeypatch):
+    """
+    Test to reproduce and debug the specific parsing issue with a known problematic feed.
+    """
+    # 1. Resolve the path to your saved XML file and read its bytes
+    # This assumes the 'test_data' folder is in the same directory as this test file.
+    current_dir = Path(__file__).parent
+    feed_path = current_dir / "test_data" / "problematic_feed.xml"
+
+    # Sanity check to ensure the file exists so the test doesn't fail for the wrong reason
+    assert feed_path.exists(), f"Could not find test feed at {feed_path}"
+
+    mock_xml_content = feed_path.read_bytes()
+
+    # 2. Mock _fetch_feed to return the local file's content
+    monkeypatch.setattr(FeedManager, "_fetch_feed", staticmethod(lambda url: mock_xml_content))
+
+    # 3. Call the parsing logic
+    # If the bug causes an unhandled exception, the test will fail right here,
+    # giving you a clean traceback to debug.
+    try:
+        title, slug, image_url, description = FeedManager.parse_feed("https://fake-url.com/feed.xml")
+        episodes = FeedManager.parse_episodes("https://fake-url.com/feed.xml")
+
+        # 4. Add assertions based on what *should* happen when the bug is fixed.
+        # For now, you can just assert that the data isn't completely empty,
+        # or place a breakpoint() here to inspect the variables.
+        assert title is not None, "Title should be parsed"
+        assert len(episodes) > 0, "Should have parsed at least one episode"
+
+    except ValueError as e:
+        # If the bug raises a specific ValueError (like d.bozo), it will get caught here.
+        pytest.fail(f"FeedManager raised an unexpected ValueError: {e}")

--- a/tests/test_processor_feeds.py
+++ b/tests/test_processor_feeds.py
@@ -1,0 +1,146 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from app.core.processor import Processor
+
+@pytest.fixture
+def mock_processor():
+    """Fixture to provide a Processor instance with mocked external dependencies."""
+    with patch("app.core.processor.EpisodeRepository") as mock_ep_repo, \
+            patch("app.core.processor.SubscriptionRepository") as mock_sub_repo, \
+            patch("app.core.processor.JobRepository"), \
+            patch("app.core.processor.Transcriber"), \
+            patch("app.core.processor.AdDetector"), \
+            patch("app.core.processor.RSSGenerator"):
+
+        processor = Processor()
+        yield processor
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_creates_new_episodes_from_feed(mock_feed_manager, mock_processor):
+    """Test that new episodes are queued (status: pending) from feed."""
+    mock_sub = MagicMock()
+    mock_sub.id = 1
+    mock_sub.feed_url = "https://example.com/feed"
+    mock_sub.retention_limit = 5
+
+    mock_processor.sub_repo.get_all.return_value = [mock_sub]
+
+    # Mock FeedManager to return one parsed episode
+    mock_feed_manager.parse_episodes.return_value = [
+        {'title': 'Episode 1', 'guid': 'guid-123'}
+    ]
+
+    # True means the episode did not exist and was created
+    mock_processor.ep_repo.create_or_ignore.return_value = True
+
+    asyncio.run(mock_processor.check_feeds())
+
+    # Verify FeedManager was used instead of requests.get
+    mock_feed_manager.parse_episodes.assert_called_once_with("https://example.com/feed")
+
+    # Verify it tried to save to the database with the correct pending status
+    mock_processor.ep_repo.create_or_ignore.assert_called_once()
+    saved_ep_data = mock_processor.ep_repo.create_or_ignore.call_args[0][0]
+    assert saved_ep_data['title'] == 'Episode 1'
+    assert saved_ep_data['status'] == 'pending'
+
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_skips_existing_episodes(mock_feed_manager, mock_processor):
+    """Test that existing episodes are handled correctly (skipped or backfilled)."""
+    mock_sub = MagicMock()
+    mock_sub.id = 1
+    mock_sub.retention_limit = 5
+    mock_processor.sub_repo.get_all.return_value = [mock_sub]
+
+    mock_feed_manager.parse_episodes.return_value = [
+        {'title': 'Episode 1', 'guid': 'guid-123'}
+    ]
+
+    # False means the episode already exists in the database
+    mock_processor.ep_repo.create_or_ignore.return_value = False
+
+    asyncio.run(mock_processor.check_feeds())
+
+    # Should attempt to backfill/update status since it's within the limit
+    mock_processor.ep_repo.update_status_by_guid.assert_called_once_with(
+        1, 'guid-123', 'pending', condition_status='unprocessed'
+    )
+
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_respects_retention_limit(mock_feed_manager, mock_processor):
+    """Test that retention limit is respected by marking older episodes unprocessed."""
+    mock_sub = MagicMock()
+    mock_sub.id = 1
+    mock_sub.retention_limit = 1 # Only the first episode should be pending
+    mock_processor.sub_repo.get_all.return_value = [mock_sub]
+
+    mock_feed_manager.parse_episodes.return_value = [
+        {'title': 'Episode 1', 'guid': 'guid-1'},
+        {'title': 'Episode 2', 'guid': 'guid-2'}
+    ]
+
+    asyncio.run(mock_processor.check_feeds())
+
+    assert mock_processor.ep_repo.create_or_ignore.call_count == 2
+
+    # Inspect the payloads sent to the database
+    call_1_args = mock_processor.ep_repo.create_or_ignore.call_args_list[0][0][0]
+    call_2_args = mock_processor.ep_repo.create_or_ignore.call_args_list[1][0][0]
+
+    assert call_1_args['status'] == 'pending'
+    assert call_2_args['status'] == 'unprocessed'
+
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_handles_feed_parsing_error(mock_feed_manager, mock_processor):
+    """Test that feed parsing errors are handled gracefully without crashing the loop."""
+    mock_sub = MagicMock()
+    mock_processor.sub_repo.get_all.return_value = [mock_sub]
+
+    # Simulate a parsing exception
+    mock_feed_manager.parse_episodes.side_effect = Exception("Invalid XML")
+
+    # This should execute and catch the exception internally, preventing a crash
+    asyncio.run(mock_processor.check_feeds())
+
+    mock_processor.ep_repo.create_or_ignore.assert_not_called()
+
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_all_subscriptions(mock_feed_manager, mock_processor):
+    """Test processing loops over all active subscriptions."""
+    mock_sub1 = MagicMock(id=1, feed_url="https://feed1.com")
+    mock_sub2 = MagicMock(id=2, feed_url="https://feed2.com")
+
+    mock_processor.sub_repo.get_all.return_value = [mock_sub1, mock_sub2]
+    mock_feed_manager.parse_episodes.return_value = []
+
+    asyncio.run(mock_processor.check_feeds())
+
+    assert mock_feed_manager.parse_episodes.call_count == 2
+
+
+@patch("app.core.processor.FeedManager")
+def test_check_feeds_with_zero_limit_skips_initial_downloads(mock_feed_manager, mock_processor):
+    """Test that a retention limit of zero sets status to unprocessed (skips downloads)."""
+    mock_sub = MagicMock()
+    mock_sub.id = 1
+    mock_sub.retention_limit = 0 # 0 means skip initial downloads
+    mock_processor.sub_repo.get_all.return_value = [mock_sub]
+
+    mock_feed_manager.parse_episodes.return_value = [
+        {'title': 'Episode 1', 'guid': 'guid-1'}
+    ]
+
+    asyncio.run(mock_processor.check_feeds())
+
+    call_args = mock_processor.ep_repo.create_or_ignore.call_args[0][0]
+    assert call_args['status'] == 'unprocessed'
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
I was seeing an error when trying to add a specific podcast.  A bit of debugging found the issue, the podcast was returning a string in the length field for one of its episodes, which would kill the feed processor as it assumed that length was an int.  I've just added an extra check on the line that had the issue to check that length is actually a number.  Added a bunch of unit tests while I was at it, including a test for the issue I am fixing.