### PR TITLE
Serve badged podcast artwork as 1400px JPEG instead of full-size PNG

### DIFF
--- a/Documentation/Architecture.md
+++ b/Documentation/Architecture.md
@@ -139,13 +139,18 @@ suppressed while the default-features group inherits.
 
 When the effective artwork-badge setting is enabled, `app/core/artwork.py` retrieves HTTP(S) source
 artwork with redirect and size validation, composites the bundled `AD FREE` badge, and atomically
-caches a JPEG under `/data/artwork/`. Output is capped at 1400x1400 and encoded at quality 82, which
-keeps it inside Apple's 1400-3000px square requirement while staying a few hundred KB rather than
-several MB. Generated feeds and the web UI use the local `/artwork/{id}.jpg` route with a content
+caches a JPEG under `/data/artwork/`. Output is capped at 1400x1400 and encoded at quality 82 to
+reduce client downloads. Source aspect ratios are preserved and small images are not enlarged.
+Generated feeds and the web UI use the local `/artwork/{id}.jpg` route with a content
 hash cache key; the encoder settings are part of that hash, so changing them republishes every URL.
 The older `/artwork/{id}.png` route is still served for clients holding cached feed XML. Disabling
 the feature clears the derived file and restores the source artwork URL. An artwork failure is
 logged but does not prevent subscription creation or feed processing.
+
+Existing PNGs remain available until the JPEG path and hash commit successfully to SQLite.
+Legacy cleanup is retried on a cache hit if it was interrupted after the commit. To convert
+existing subscriptions after upgrading, save the global subscription settings once; this
+reconciles artwork and republishes feeds with the new cache keys.
 
 ### Job State
 

--- a/Documentation/Architecture.md
+++ b/Documentation/Architecture.md
@@ -139,10 +139,13 @@ suppressed while the default-features group inherits.
 
 When the effective artwork-badge setting is enabled, `app/core/artwork.py` retrieves HTTP(S) source
 artwork with redirect and size validation, composites the bundled `AD FREE` badge, and atomically
-caches a PNG under `/data/artwork/`. Generated feeds and the web UI use the local `/artwork/{id}.png`
-route with a content hash cache key. Disabling the feature clears the derived file and restores the
-source artwork URL. An artwork failure is logged but does not prevent subscription creation or feed
-processing.
+caches a JPEG under `/data/artwork/`. Output is capped at 1400x1400 and encoded at quality 82, which
+keeps it inside Apple's 1400-3000px square requirement while staying a few hundred KB rather than
+several MB. Generated feeds and the web UI use the local `/artwork/{id}.jpg` route with a content
+hash cache key; the encoder settings are part of that hash, so changing them republishes every URL.
+The older `/artwork/{id}.png` route is still served for clients holding cached feed XML. Disabling
+the feature clears the derived file and restores the source artwork URL. An artwork failure is
+logged but does not prevent subscription creation or feed processing.
 
 ### Job State
 

--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reduce badged podcast artwork to JPEG at quality 82, with a maximum edge of 1400px, contributed by [Paul McManus (@pmacca) in PR #22](https://github.com/jdcb4/podcast-ad-remover/pull/22). Keep cached PNG feed URLs working and retain the old image until the replacement path commits successfully. Save global subscription settings once after upgrading to regenerate existing artwork and feeds.
 - Add administrator-managed unified-feed preferences for its name, description, podcast-name episode-title prefix, and external artwork URL, contributed by [Paul McManus (@pmacca) in PR #20](https://github.com/jdcb4/podcast-ad-remover/pull/20). Preserve the existing address and defaults, validate RSS-safe metadata, include authentication in the settings-page feed address, and explain unavailable HTTP artwork previews.
 - Make `dev` the GitHub default and rename production `master` to `main`; align CI, release guards and Unraid template URLs. Require verification on both long-lived branches, clean up merged branches, and retain the abandoned local-LLM experiment under an archive tag.
 

--- a/Documentation/VERIFICATION.md
+++ b/Documentation/VERIFICATION.md
@@ -85,6 +85,8 @@ Automated coverage verifies:
   and cleanup behavior after global retention changes;
 - backward-compatible API updates and all four inheritance flags;
 - artwork URL validation, image limits, compositing/cache behavior, cleanup, and RSS output;
+- JPEG dimensions/transparency, legacy PNG serving, preservation after a failed database write
+  or commit, and retry of interrupted legacy-artwork cleanup;
 - backward-compatible unified-feed defaults, customized channel metadata and external artwork,
   optional podcast-name title prefixes, settings validation, and reset behavior;
 - XML-invalid metadata rejection without replacing the published feed, valid legacy metadata

--- a/app/core/artwork.py
+++ b/app/core/artwork.py
@@ -23,17 +23,25 @@ logger = logging.getLogger(__name__)
 
 MAX_ARTWORK_BYTES = 12 * 1024 * 1024
 MAX_ARTWORK_EDGE = 8000
-OUTPUT_MAX_EDGE = 3000
+# Apple's podcast artwork spec allows 1400-3000px square. 1400 is the smallest
+# compliant size, and clients only ever draw a thumbnail from it.
+OUTPUT_MAX_EDGE = 1400
+JPEG_QUALITY = 82
 BADGE_SCALE = 0.30
 BADGE_MARGIN = 0.035
 BADGE_PATH = Path(__file__).resolve().parents[1] / "web" / "static" / "ad_free_badge.png"
+LEGACY_OUTPUT_SUFFIX = ".png"
+# Part of the cache digest, so changing the encoding regenerates every file and
+# publishes a new ?v= for URLs that clients cache as immutable for a year.
+ENCODE_SALT = f"artwork-v2:jpeg:{OUTPUT_MAX_EDGE}:q{JPEG_QUALITY}".encode()
 
 
 def effective_artwork_url(subscription, base_url: str) -> str | None:
     path = getattr(subscription, "watermarked_image_path", None)
     if getattr(subscription, "watermark_artwork", False) and path and Path(path).is_file():
         version = getattr(subscription, "watermarked_image_hash", None) or "current"
-        return f"{base_url.rstrip('/')}/artwork/{subscription.id}.png?v={version[:12]}"
+        suffix = Path(path).suffix or ".jpg"
+        return f"{base_url.rstrip('/')}/artwork/{subscription.id}{suffix}?v={version[:12]}"
     return getattr(subscription, "image_url", None)
 
 
@@ -70,13 +78,28 @@ class ArtworkWatermarker:
 
     @staticmethod
     def _output_path(subscription_id: int) -> Path:
-        return Path(settings.ARTWORK_DIR) / f"{int(subscription_id)}.png"
+        return Path(settings.ARTWORK_DIR) / f"{int(subscription_id)}.jpg"
+
+    @staticmethod
+    def _remove_legacy_output(subscription_id: int) -> None:
+        """Delete the PNG output written by releases before the JPEG switch."""
+        legacy = Path(settings.ARTWORK_DIR) / f"{int(subscription_id)}{LEGACY_OUTPUT_SUFFIX}"
+        root = Path(settings.ARTWORK_DIR).resolve()
+        try:
+            resolved = legacy.resolve()
+            if resolved.parent == root and resolved.is_file():
+                resolved.unlink()
+        except OSError as exc:
+            logger.warning(
+                "Could not remove legacy artwork for subscription %s: %s", subscription_id, exc
+            )
 
     def clear(self, subscription_id: int) -> None:
         output = self._output_path(subscription_id).resolve()
         root = Path(settings.ARTWORK_DIR).resolve()
         if output.parent == root and output.exists():
             output.unlink()
+        self._remove_legacy_output(subscription_id)
         with get_db_connection() as conn:
             conn.execute(
                 """
@@ -96,7 +119,7 @@ class ArtworkWatermarker:
 
         source = self._download(sub.image_url)
         badge_bytes = BADGE_PATH.read_bytes()
-        digest = hashlib.sha256(source + badge_bytes + b"artwork-v1").hexdigest()
+        digest = hashlib.sha256(source + badge_bytes + ENCODE_SALT).hexdigest()
         output = self._output_path(subscription_id)
         if (
             sub.watermarked_image_hash == digest
@@ -132,10 +155,21 @@ class ArtworkWatermarker:
         )
         artwork.alpha_composite(badge, position)
 
+        # JPEG has no alpha channel, so composite the result onto white.
+        flattened = Image.new("RGB", artwork.size, (255, 255, 255))
+        flattened.paste(artwork, mask=artwork.getchannel("A"))
+
         output.parent.mkdir(parents=True, exist_ok=True)
-        temporary = output.with_suffix(".tmp.png")
-        artwork.save(temporary, format="PNG", optimize=True)
+        temporary = output.with_suffix(".tmp.jpg")
+        flattened.save(
+            temporary,
+            format="JPEG",
+            quality=JPEG_QUALITY,
+            optimize=True,
+            progressive=True,
+        )
         os.replace(temporary, output)
+        self._remove_legacy_output(subscription_id)
 
         with get_db_connection() as conn:
             conn.execute(

--- a/app/core/artwork.py
+++ b/app/core/artwork.py
@@ -126,6 +126,8 @@ class ArtworkWatermarker:
             and sub.watermarked_image_path
             and Path(sub.watermarked_image_path).is_file()
         ):
+            if Path(sub.watermarked_image_path).resolve() == output.resolve():
+                self._remove_legacy_output(subscription_id)
             return sub.watermarked_image_path
 
         try:
@@ -169,7 +171,6 @@ class ArtworkWatermarker:
             progressive=True,
         )
         os.replace(temporary, output)
-        self._remove_legacy_output(subscription_id)
 
         with get_db_connection() as conn:
             conn.execute(
@@ -181,5 +182,8 @@ class ArtworkWatermarker:
                 (str(output), digest, subscription_id),
             )
             conn.commit()
+        # The database must point to the JPEG before its predecessor is removed.
+        # If publication fails, existing feed URLs can still serve the PNG.
+        self._remove_legacy_output(subscription_id)
         logger.info("Generated ad-free artwork for subscription %s", subscription_id)
         return str(output)

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -2657,6 +2657,9 @@ async def update_settings(
     background_tasks.add_task(post_update_tasks, id)
     return RedirectResponse(url=f"/subscriptions/{id}", status_code=303)
 
+@router.get("/artwork/{subscription_id}.jpg")
+# Feed XML cached by a client can still reference the pre-JPEG .png URL. Serving
+# the current file under both paths keeps those clients from getting a 404.
 @router.get("/artwork/{subscription_id}.png")
 async def serve_watermarked_artwork(subscription_id: int):
     sub = sub_repo.get_by_id(subscription_id)
@@ -2670,7 +2673,7 @@ async def serve_watermarked_artwork(subscription_id: int):
 
     return FileResponse(
         path,
-        media_type="image/png",
+        media_type="image/jpeg" if path.suffix == ".jpg" else "image/png",
         headers={"Cache-Control": "public, max-age=31536000, immutable"},
     )
 

--- a/tests/test_artwork_watermark.py
+++ b/tests/test_artwork_watermark.py
@@ -1,5 +1,7 @@
 import hashlib
 import io
+import sqlite3
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -179,6 +181,72 @@ def test_effective_artwork_url_follows_the_stored_file_extension(isolated_data_d
 
     after = effective_artwork_url(repo.get_by_id(sub.id), "https://podcasts.example")
     assert after.startswith(f"https://podcasts.example/artwork/{sub.id}.jpg?v=")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["execute", "commit"])
+async def test_failed_jpeg_publication_keeps_legacy_artwork_available(
+    isolated_data_dir, monkeypatch, failure_point
+):
+    source = _image_bytes()
+    repo, sub = _watermarked_subscription("failed-publication", source, monkeypatch)
+    legacy = Path(settings.ARTWORK_DIR) / f"{sub.id}.png"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_bytes(source)
+    old_hash = hashlib.sha256(source + BADGE_PATH.read_bytes() + b"artwork-v1").hexdigest()
+    with get_db_connection() as conn:
+        conn.execute(
+            "UPDATE subscriptions SET watermarked_image_path=?, watermarked_image_hash=? WHERE id=?",
+            (str(legacy), old_hash, sub.id),
+        )
+        conn.commit()
+
+    @contextmanager
+    def failing_connection():
+        with get_db_connection() as conn:
+            class FailingPublication:
+                def execute(self, *args):
+                    if failure_point == "execute":
+                        raise sqlite3.OperationalError("database is locked")
+                    return conn.execute(*args)
+
+                def commit(self):
+                    raise sqlite3.OperationalError("commit failed")
+
+            yield FailingPublication()
+
+    with monkeypatch.context() as patch:
+        patch.setattr("app.core.artwork.get_db_connection", failing_connection)
+        with pytest.raises(sqlite3.OperationalError):
+            ArtworkWatermarker().reconcile(sub.id)
+
+    saved = repo.get_by_id(sub.id)
+    assert saved.watermarked_image_path == str(legacy)
+    assert saved.watermarked_image_hash == old_hash
+    assert legacy.read_bytes() == source
+    response = await serve_watermarked_artwork(sub.id)
+    assert response.media_type == "image/png"
+    assert Path(response.path).read_bytes() == source
+
+    # A normal retry must finish the transition and remove the superseded PNG.
+    generated = ArtworkWatermarker().reconcile(sub.id)
+    assert generated.endswith(".jpg")
+    assert not legacy.exists()
+    assert repo.get_by_id(sub.id).watermarked_image_path == generated
+    assert (await serve_watermarked_artwork(sub.id)).media_type == "image/jpeg"
+
+
+def test_cached_jpeg_retries_interrupted_legacy_cleanup(isolated_data_dir, monkeypatch):
+    _, sub = _watermarked_subscription("interrupted-cleanup", _image_bytes(), monkeypatch)
+    service = ArtworkWatermarker()
+    generated = service.reconcile(sub.id)
+    legacy = Path(settings.ARTWORK_DIR) / f"{sub.id}.png"
+    legacy.write_bytes(_image_bytes())
+    before = Path(generated).stat().st_mtime_ns
+
+    assert service.reconcile(sub.id) == generated
+    assert Path(generated).stat().st_mtime_ns == before
+    assert not legacy.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_artwork_watermark.py
+++ b/tests/test_artwork_watermark.py
@@ -1,18 +1,56 @@
+import hashlib
 import io
 from pathlib import Path
 
+import pytest
 from PIL import Image
 
-from app.core.artwork import ArtworkWatermarker, effective_artwork_url
+from app.core.artwork import BADGE_PATH, ArtworkWatermarker, effective_artwork_url
+from app.core.config import settings
 from app.core.models import SubscriptionCreate
 from app.infra.database import get_db_connection, init_db
 from app.infra.repository import SubscriptionRepository
+from app.web.router import router as web_router
+from app.web.router import serve_watermarked_artwork
+
+
+CACHE_CONTROL = "public, max-age=31536000, immutable"
 
 
 def _image_bytes(size=(600, 600), color=(180, 40, 80)):
     output = io.BytesIO()
     Image.new("RGB", size, color).save(output, format="PNG")
     return output.getvalue()
+
+
+def _transparent_corner_image_bytes(size=(600, 600), color=(180, 40, 80, 255)):
+    """An RGBA image whose top-left quadrant is fully transparent."""
+    image = Image.new("RGBA", size, color)
+    hole = Image.new("RGBA", (size[0] // 2, size[1] // 2), (0, 0, 0, 0))
+    image.paste(hole, (0, 0))
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _watermarked_subscription(slug, source_bytes, monkeypatch):
+    """Create a subscription with watermarking enabled and a stubbed artwork download."""
+    init_db()
+    repo = SubscriptionRepository()
+    with get_db_connection() as conn:
+        conn.execute("UPDATE app_settings SET default_watermark_artwork = 1 WHERE id = 1")
+        conn.commit()
+
+    sub = repo.create(
+        SubscriptionCreate(feed_url=f"https://example.com/{slug}.xml"),
+        slug.title(),
+        slug,
+        image_url=f"https://example.com/{slug}.png",
+    )
+    monkeypatch.setattr(
+        ArtworkWatermarker, "_download", staticmethod(lambda url: source_bytes)
+    )
+    return repo, sub
 
 
 def test_watermark_generation_is_inherited_cached_and_removable(isolated_data_dir, monkeypatch):
@@ -35,15 +73,18 @@ def test_watermark_generation_is_inherited_cached_and_removable(isolated_data_di
     refreshed = repo.get_by_id(sub.id)
 
     assert generated is not None
+    assert generated.endswith(".jpg")
     assert Path(generated).is_file()
     assert refreshed.watermark_artwork is True
     assert refreshed.watermarked_image_path == generated
     assert len(refreshed.watermarked_image_hash) == 64
     assert effective_artwork_url(refreshed, "https://podcasts.example").startswith(
-        f"https://podcasts.example/artwork/{sub.id}.png?v="
+        f"https://podcasts.example/artwork/{sub.id}.jpg?v="
     )
 
     with Image.open(generated) as image:
+        assert image.format == "JPEG"
+        assert image.mode == "RGB"
         assert image.size == (600, 600)
         assert image.getpixel((560, 560))[:3] != (180, 40, 80)
 
@@ -52,6 +93,112 @@ def test_watermark_generation_is_inherited_cached_and_removable(isolated_data_di
     cleared = repo.get_by_id(sub.id)
     assert not Path(generated).exists()
     assert cleared.watermarked_image_path is None
+
+
+def test_watermark_downscales_large_source_to_the_output_cap(isolated_data_dir, monkeypatch):
+    _, sub = _watermarked_subscription("large", _image_bytes(size=(3000, 3000)), monkeypatch)
+
+    generated = ArtworkWatermarker().reconcile(sub.id)
+
+    with Image.open(generated) as image:
+        assert image.size == (1400, 1400)
+    assert Path(generated).stat().st_size < 500 * 1024
+
+
+def test_watermark_does_not_upscale_a_small_source(isolated_data_dir, monkeypatch):
+    _, sub = _watermarked_subscription("small", _image_bytes(size=(800, 800)), monkeypatch)
+
+    generated = ArtworkWatermarker().reconcile(sub.id)
+
+    with Image.open(generated) as image:
+        assert image.size == (800, 800)
+
+
+def test_watermark_flattens_transparency_onto_white(isolated_data_dir, monkeypatch):
+    _, sub = _watermarked_subscription("alpha", _transparent_corner_image_bytes(), monkeypatch)
+
+    generated = ArtworkWatermarker().reconcile(sub.id)
+
+    with Image.open(generated) as image:
+        assert image.mode == "RGB"
+        red, green, blue = image.getpixel((10, 10))
+    assert min(red, green, blue) > 240
+
+
+def test_reconcile_regenerates_and_removes_a_stale_png_output(isolated_data_dir, monkeypatch):
+    """A pre-migration PNG output is replaced by a JPEG and its stored hash changes."""
+    source = _image_bytes()
+    repo, sub = _watermarked_subscription("stale", source, monkeypatch)
+
+    legacy_png = Path(settings.ARTWORK_DIR) / f"{sub.id}.png"
+    legacy_png.parent.mkdir(parents=True, exist_ok=True)
+    legacy_png.write_bytes(source)
+    legacy_digest = hashlib.sha256(source + BADGE_PATH.read_bytes() + b"artwork-v1").hexdigest()
+    with get_db_connection() as conn:
+        conn.execute(
+            """
+            UPDATE subscriptions
+            SET watermarked_image_path = ?, watermarked_image_hash = ?
+            WHERE id = ?
+            """,
+            (str(legacy_png), legacy_digest, sub.id),
+        )
+        conn.commit()
+
+    generated = ArtworkWatermarker().reconcile(sub.id)
+    refreshed = repo.get_by_id(sub.id)
+
+    assert generated.endswith(".jpg")
+    assert Path(generated).is_file()
+    assert not legacy_png.exists()
+    assert refreshed.watermarked_image_hash != legacy_digest
+
+
+def test_effective_artwork_url_follows_the_stored_file_extension(isolated_data_dir, monkeypatch):
+    """During migration the URL must match the file actually on disk."""
+    repo, sub = _watermarked_subscription("transition", _image_bytes(), monkeypatch)
+
+    legacy_png = Path(settings.ARTWORK_DIR) / f"{sub.id}.png"
+    legacy_png.parent.mkdir(parents=True, exist_ok=True)
+    legacy_png.write_bytes(_image_bytes())
+    with get_db_connection() as conn:
+        conn.execute(
+            """
+            UPDATE subscriptions
+            SET watermarked_image_path = ?, watermarked_image_hash = ?
+            WHERE id = ?
+            """,
+            (str(legacy_png), "a" * 64, sub.id),
+        )
+        conn.commit()
+
+    before = effective_artwork_url(repo.get_by_id(sub.id), "https://podcasts.example")
+    assert before.startswith(f"https://podcasts.example/artwork/{sub.id}.png?v=")
+
+    ArtworkWatermarker().reconcile(sub.id)
+
+    after = effective_artwork_url(repo.get_by_id(sub.id), "https://podcasts.example")
+    assert after.startswith(f"https://podcasts.example/artwork/{sub.id}.jpg?v=")
+
+
+@pytest.mark.asyncio
+async def test_artwork_route_serves_jpeg_with_immutable_caching(isolated_data_dir, monkeypatch):
+    _, sub = _watermarked_subscription("served", _image_bytes(), monkeypatch)
+    generated = ArtworkWatermarker().reconcile(sub.id)
+
+    response = await serve_watermarked_artwork(sub.id)
+
+    assert str(response.path) == generated
+    assert response.media_type == "image/jpeg"
+    assert response.headers["cache-control"] == CACHE_CONTROL
+
+
+def test_artwork_route_still_accepts_the_legacy_png_path():
+    """Clients holding stale feed XML must not get a 404 for the old .png URL."""
+    paths = {getattr(route, "path", None) for route in web_router.routes}
+
+    assert "/artwork/{subscription_id}.jpg" in paths
+    assert "/artwork/{subscription_id}.png" in paths
 
 
 def test_watermark_rejects_extreme_dimensions(isolated_data_dir, monkeypatch):


### PR DESCRIPTION
Hello !

I was wondering why my podcast client kept bogging down and showing placeholder images instead of the actual podcast artwork all the time. It turns out the server was serving 12MB artwork images! This only seems to happen when the "ad free" stamp is placed over the top. This PR is an optimisation to that stamping process.

The app is also unnecessarily using PNG which is lossless and many times larger in size than a JPEG. 

I'm running this on my server now, will update if there are any issues.

Claude ~slop~ summary below...

=====

Derived artwork is cached as a PNG at up to 3000x3000, which produces multi-megabyte files for photographic cover art. Podcast clients fetch the single URL in the feed and downscale locally to draw a thumbnail — about 126px on a typical phone — so nearly all of those bytes are wasted. On one real feed set, a mobile client's image cache held ~39 MB of artwork from the server.

This caps output at 1400x1400, the smallest size Apple's podcast artwork spec allows, and encodes JPEG quality 82. The badge composite is flattened onto white because JPEG has no alpha channel.

Measured on five real subscriptions, re-encoded through the changed code path:

| Artwork | Before (3000px PNG) | After (1400px JPEG q82) | Saved |
| --- | --- | --- | --- |
| 1 | 12.35 MB | 385 KB | 97.0% |
| 2 | 6.79 MB | 285 KB | 95.9% |
| 3 | 6.50 MB | 320 KB | 95.2% |
| 4 | 3.56 MB | 161 KB | 95.6% |
| 5 | 1.77 MB | 176 KB | 90.3% |
| **Total** | **30.96 MB** | **1.33 MB** | **95.8%** |

Every output verified square, RGB, no larger than 1400x1400, and under 500 KB.

### Notes

- The encoder settings are part of the artwork content hash, so existing subscriptions regenerate on their next reconcile and every URL gets a new `?v=`. This matters because artwork is served with a year of `immutable` caching — without a new cache key, no client would ever re-fetch.
- Feed URLs follow the extension of the file actually on disk, so a subscription flips from `.png` to `.jpg` atomically with its regeneration. The old `/artwork/{id}.png` route still serves the current file, so a client holding cached feed XML gets an image rather than a 404 and a permanently blank placeholder.
- Stale PNG outputs are removed as each subscription regenerates.
- Sources smaller than 1400px are not upscaled, matching the previous behaviour.
- **After deploying, save global subscription settings once** to reconcile existing subscriptions and republish the feeds.
- 254 tests pass, 7 of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
