### PR TITLE
Establish protected dev and main branch workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-      - master
+      - main
   pull_request:
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ Treat the following `Documentation/` files as active guidance when they apply:
 - `Documentation/Deployment.md` and `Documentation/Unraid_Deployment.md`: Docker, compose, and Unraid deployment expectations.
 - `Documentation/Environment_Variables.md`: environment configuration and database-backed runtime settings.
 - `Documentation/VERSIONING.md`: version bump and release-tag rules.
+- `Documentation/GIT_WORKFLOW.md`: branch protection, worktrees, cleanup and clone migration.
 - `Documentation/VERIFICATION.md`: required local, Docker, and release checks.
 - `Documentation/CHANGELOG.md`: unreleased and released change history.
 - `Documentation/DECISIONS.md`: active decision log.
@@ -52,9 +53,11 @@ Commit after each significant coherent change, once verification appropriate to 
 
 ## Branch And Promotion Workflow
 
-- `dev` is the primary integration branch. Start normal feature and fix branches from `dev`, and merge completed work back into `dev`.
-- `master` is the production branch. Do not use it for day-to-day development.
-- Do not merge `dev` into `master`, push `master`, bump a production version, publish SemVer tags, or update `latest` unless Joe explicitly instructs you to promote a release.
+- `dev` is the GitHub default and primary integration branch. Start normal feature and fix branches from `dev`, and merge completed work back into `dev` after verification passes.
+- `main` is the production branch. Do not use it for day-to-day development. The former `master` branch was renamed to `main` on 2026-09-06; do not recreate it.
+- Do not merge `dev` into `main`, push `main`, bump a production version, publish SemVer tags, or update `latest` unless Joe explicitly instructs you to promote a release or authorizes a specific repository-maintenance change.
+- Keep feature branches and worktrees only for active, unmerged work. Before removing either, inspect uncommitted files and prove its commits are merged; preserve unique abandoned work under an archive tag before deleting its branch. See `Documentation/GIT_WORKFLOW.md`.
+- GitHub requires the `verify` check on `dev` and `main` and blocks branch deletion and force pushes. The administrator bypass is for deliberate recovery, not routine agent work.
 - Dev Docker images use the rolling `jdcb4/podcast-ad-remover:dev` tag plus the immutable `jdcb4/podcast-ad-remover:dev-<git-sha>` tag. They must never update `latest` or a SemVer tag.
 - A production promotion begins only after the Dev image has been tested and Joe gives explicit approval. Follow `Documentation/VERSIONING.md` for the promotion checklist.
 
@@ -64,7 +67,7 @@ Commit after each significant coherent change, once verification appropriate to 
 - Any database schema change needs a backward-compatible migration path and a rollback/backup note.
 - Do not commit secrets, API keys, real session secrets, downloaded audio, transcripts, generated models, or local database files.
 - Do not push a Docker release unless explicitly asked.
-- Do not promote `dev` to `master` unless explicitly asked.
+- Do not promote `dev` to `main` unless explicitly asked.
 - Keep `package.json` and `package-lock.json` versions aligned.
 - Update `Documentation/CHANGELOG.md` in the same change as a version bump.
 - Docker releases use `jdcb4/podcast-ad-remover:<version>` and `jdcb4/podcast-ad-remover:latest`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Have a great idea? Open an issue to discuss it! We love hearing how to make the 
 
 Please ensure your code is clean and, where possible, documented.
 
-`dev` is the normal integration branch. `master` represents production and receives changes only through an explicitly approved release promotion after the Dev image has been tested.
+`dev` is the GitHub default and normal integration branch. `main` represents production and receives application changes only through an explicitly approved release promotion after the Dev image has been tested. Both branches require the GitHub Actions `verify` check. Delete feature branches after merging; preserve unmerged work. See [Git workflow](Documentation/GIT_WORKFLOW.md) for worktrees, cleanup and updating older clones.
 
 ## Development Setup
 

--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Make `dev` the GitHub default and rename production `master` to `main`; align CI, release guards and Unraid template URLs. Require verification on both long-lived branches, clean up merged branches, and retain the abandoned local-LLM experiment under an archive tag.
+
 ## 1.13.0 - 2026-09-06
 
 - Keep published-episode counts, previews and listen totals stable while replacement processing is queued, running, cancelled or failed.

--- a/Documentation/DECISIONS.md
+++ b/Documentation/DECISIONS.md
@@ -2,9 +2,22 @@
 
 This is a lightweight decision log. Keep entries short, dated, and focused on choices that future maintainers may otherwise revisit.
 
+## 2026-09-06: Keep dev and main as the only long-lived branches
+
+Joe requested `dev` as the working/default branch and `main` as production. Rename `master` to
+`main` without rewriting history. Apply the existing deletion/force-push protection to both real
+branches and require the GitHub Actions `verify` check. Keep the existing administrator recovery
+bypass; do not use it for routine changes. Feature branches and worktrees exist only while work is
+active and unmerged, and merged pull-request branches are deleted automatically.
+
+Preserve the concluded local-LLM experiment at tag `archive/local-llm-transcript-chunking` before
+removing its inactive branch. Open contributor pull requests remain open and target `dev`.
+Repository-maintenance changes authorized for this rename do not publish or deploy a new app
+release. See [Git workflow](GIT_WORKFLOW.md) for the operating procedure and cleanup record.
+
 ## 2026-08-10: Integrate on dev and explicitly promote production releases
 
-`dev` is the primary integration branch and `master` is the production branch. Development images share the production Docker repository but use `dev` as a rolling tag and `dev-<git-sha>` as the traceable immutable tag. They never update SemVer tags or `latest`. After a Dev image has been tested, merging to `master` and publishing production tags still require Joe's explicit instruction.
+`dev` is the primary integration branch and `main` (named `master` until 2026-09-06) is the production branch. Development images share the production Docker repository but use `dev` as a rolling tag and `dev-<git-sha>` as the traceable immutable tag. They never update SemVer tags or `latest`. After a Dev image has been tested, merging to `main` and publishing production tags still require Joe's explicit instruction.
 
 ## 2026-05-19: Keep SQLite and `/data` as the migration anchor
 
@@ -73,9 +86,9 @@ to an operator-supplied URL. Arbitrary model slugs and keyed or keyless endpoint
 The 4B-to-72B evaluation completed only 20 of 30 runs and passed 6 of 30 interval-quality gates.
 Every local-class candidate missed the short promotion, and structured-output failures remained
 common. The chunking implementation and harness are preserved on
-`experimental/local-llm-transcript-chunking` for research, but are not part of the production
+tag `archive/local-llm-transcript-chunking` (formerly the experimental branch) for research, but are not part of the production
 application and have no planned further development. Sanitized HTML, Markdown, and JSON results
-remain on `master` so the decision and exact detections are inspectable.
+remain on `main` so the decision and exact detections are inspectable.
 
 ## 2026-07-25: Use explicit group inheritance without discarding podcast overrides
 

--- a/Documentation/Deployment.md
+++ b/Documentation/Deployment.md
@@ -162,7 +162,7 @@ This path targets `linux/arm64`, tags the image as `jdcb4/podcast-ad-remover:exp
 
 ## Release Publishing
 
-Production releases are promoted from a tested Dev revision only after explicit approval. The release helper runs only from a clean `master` checkout.
+Production releases are promoted from a tested Dev revision only after explicit approval. The release helper runs only from a clean `main` checkout.
 
 Before upgrading an existing install with important data, dry-run database migrations against a copy:
 

--- a/Documentation/GIT_WORKFLOW.md
+++ b/Documentation/GIT_WORKFLOW.md
@@ -1,0 +1,138 @@
+# Git workflow
+
+## Branches and checks
+
+| Ref | Purpose | Lifetime |
+| --- | --- | --- |
+| `dev` | GitHub default; normal integration and development builds | Permanent |
+| `main` | Production source; explicitly approved promotions of tested Dev revisions | Permanent |
+| `codex/<topic>`, `feature/<topic>`, `fix/<topic>` | One active change, based on and merged into `dev` | Delete after merging |
+| `archive/<topic>` tag | Preserve concluded, unmerged research without keeping an active branch | Retained for reference |
+
+Both permanent branches block deletion and force pushes and require the GitHub Actions `verify`
+check. Pull requests must be current with their target branch before merging. GitHub automatically
+deletes merged pull-request branches; `dev` is the default and both permanent branches are protected.
+The existing administrator bypass remains available for deliberate recovery. Passing checks do not
+replace Joe's explicit production-promotion approval, and routine agents must not bypass the rules.
+
+GitHub does not deploy images automatically. See [VERSIONING.md](VERSIONING.md) for testing the
+exact Dev image, approval, fast-forward promotion to `main`, versioning and Docker publication.
+Repository-maintenance changes to `main` also require explicit authorization; a branch rename is
+not an application release.
+
+## Normal work
+
+Start with a clean checkout, update `dev`, and create one branch for the change:
+
+```bash
+git fetch origin --prune
+git switch dev
+git pull --ff-only
+git switch -c codex/example-change
+```
+
+Run `npm run verify`, commit the coherent change, push its branch, and open a pull request targeting
+`dev`. Wait for the required `verify` check. After merging, return the main checkout to `dev`, pull
+with `--ff-only`, and remove the merged local branch. Keep concurrent work on separate branches.
+Do not reuse a merged branch for a different task.
+
+A separate worktree is optional for simultaneous changes:
+
+```bash
+git worktree add ../podcast-example-change -b codex/example-change dev
+```
+
+Use this instead of the preceding branch-creation command, with a new branch name and directory.
+Before removing a worktree, inspect its `git status --short --untracked-files=all`, review ignored
+local files with `git status --short --ignored`, and preserve anything valuable. Confirm its commits
+are merged, then use `git worktree remove <path>` without `--force`. Remove its branch only after
+the worktree has been removed. Do not delete a directory to unregister a worktree.
+
+## Periodic cleanup
+
+```bash
+git fetch origin --prune
+git worktree list --porcelain
+git worktree prune --dry-run --verbose
+git branch -vv
+git branch --merged dev
+```
+
+Protect `dev` and `main` from cleanup. For each other branch, check for open pull requests or active
+tasks and use `git merge-base --is-ancestor <branch> dev` to prove ancestry before deleting it.
+`git branch -d <branch>` removes a merged local branch; `git push origin --delete <branch>` removes
+a reviewed, merged remote branch. Recheck the remote tip before deletion if other agents may be
+working on it. Age alone and a missing upstream do not prove that work is disposable.
+
+Squash-merged branches may not pass the ancestry check. Inspect their pull request and diff before
+removal. Preserve unique concluded work under an annotated `archive/<topic>` tag and verify that
+the pushed tag resolves to the original branch tip before removing the branch. Never publish an
+archive as a SemVer tag or Docker release. Prune worktree metadata only after confirming the old
+directory is gone and has no recoverable work.
+
+## Updating clones that still use master
+
+The production branch was renamed on 2026-09-06. In an older clone, first inspect local changes and
+branch divergence. If a local `master` exists and `main` does not, rename it without resetting it:
+
+```bash
+git branch -m master main
+git fetch origin --prune
+git branch --set-upstream-to=origin/main main
+git remote set-head origin -a
+git switch dev
+git branch --set-upstream-to=origin/dev dev
+git pull --ff-only
+```
+
+If `dev` does not exist locally, use `git switch --track origin/dev` instead. If both `master` and
+`main` already exist, compare them and preserve unique commits before removing either. Do not
+recreate `master` on the remote.
+
+Update external scripts and saved raw-file URLs from `/master/` to `/main/`. In particular, older
+Unraid templates may retain the old `TemplateURL` or icon URL; the checked-in template uses `main`.
+GitHub redirects ordinary branch URLs but does not redirect raw-file URLs or old `git pull`
+targets. See [GitHub's branch-rename guidance](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch).
+
+## Cleanup record: 2026-09-06
+
+The audit started from clean `dev` at `98978437ef6da0ab7a051ade450bb25fc4fe0682`, identical to
+production `master`. There was one registered worktree and no stale/prunable worktree metadata.
+Twelve leftover local branches were proven to be ancestors of `dev` and removed:
+
+```text
+DocumentationUpdate
+agent/custom-llm-endpoint-main
+audit
+audit-work
+codex/assessment-improvements
+codex/bulk-subscription-delete
+codex/dev-rollout-fixes
+codex/fix-bulk-delete-submit
+codex/queue-stall-resilience
+codex/version-bulk-js-asset
+feature/subscription-management-improvements
+feature/youtube-sources
+```
+
+The only unmerged owned branch was the explicitly concluded local-LLM experiment, with 14 unique
+commits. Its complete history is preserved by annotated tag `archive/local-llm-transcript-chunking`
+at `96fa4f51646538c025f5870229657953b256ad88`; its local and remote branch were removed. The research
+decision and results remain in [LOCAL_LLM_EVALUATION.md](LOCAL_LLM_EVALUATION.md). A verified Git
+bundle plus original refs and repository settings were also saved under the local Git directory's
+`maintenance-backups/git-structure-20260906-190237/` before cleanup.
+
+Five open contributor pull requests (#9, #19, #20, #21 and #22) were preserved in their forks;
+#9 and #19 were retargeted to `dev`. Their code was not merged or discarded by this cleanup.
+Only `dev` and `main` remain as owned branches after the maintenance change is integrated.
+
+The previous rule protected a nonexistent `main` branch while `master` and `dev` were unprotected.
+The repaired rule covers both permanent branches and requires `verify` from GitHub Actions.
+The repository default is now `dev`, and merged pull-request branch deletion is enabled.
+The existing production 1.13.0 image and data are unaffected by this Git maintenance.
+
+Local verification passed `npm run verify`: 318 Python tests, Python syntax, the CSS build and both
+dependency audits. The release-guard tests accept clean `main` and reject `dev`, the old `master`,
+feature branches, detached HEAD and dirty `main`. GitHub verification is required before integration.
+No Docker build or deployment is needed for this repository configuration change. Other clones and
+external consumers of the old raw URLs were not inspected; use the migration instructions above.

--- a/Documentation/LOCAL_LLM_EVALUATION.md
+++ b/Documentation/LOCAL_LLM_EVALUATION.md
@@ -1,6 +1,6 @@
 # Local LLM Evaluation
 
-Last updated: 2026-07-24.
+Research completed: 2026-07-24. Archive location updated: 2026-09-06.
 
 ## Purpose
 
@@ -14,10 +14,11 @@ advanced option; the benchmark does not change the product's cloud-first directi
 
 **Outcome:** transcript chunking for smaller/local models is concluded as an unsuccessful product
 experiment. The complete implementation and test harness are retained on the
-[`experimental/local-llm-transcript-chunking`](https://github.com/jdcb4/podcast-ad-remover/tree/experimental/local-llm-transcript-chunking)
-branch for inspection, but there is no current intention to continue developing it or merge it into
+[`archive/local-llm-transcript-chunking`](https://github.com/jdcb4/podcast-ad-remover/tree/archive/local-llm-transcript-chunking)
+tag for inspection, but there is no current intention to continue developing it or merge it into
 the production application. The separately useful configurable OpenAI-compatible endpoint is
-retained on `master` without chunking.
+retained on `main` without chunking. The inactive experimental branch was removed after its tip,
+`96fa4f51646538c025f5870229657953b256ad88`, was preserved under that annotated archive tag.
 
 The detailed, self-contained comparison is available in
 [`LOCAL_LLM_EVALUATION_REPORT.html`](LOCAL_LLM_EVALUATION_REPORT.html). It includes run and quality
@@ -152,8 +153,8 @@ integration, not the detection quality of either model.
 
 ## Preserved Research Materials
 
-The experimental branch retains the evaluator, versioned model matrix, chunking implementation,
-automated chunk-planning tests, and complete commit history. This `master` branch intentionally
+The archive tag retains the evaluator, versioned model matrix, chunking implementation,
+automated chunk-planning tests, and complete commit history. The production `main` branch intentionally
 retains only the sanitized research results and reports.
 
 The corpus itself is not committed. The report artifacts contain episode IDs, timing intervals,

--- a/Documentation/PRODUCTION_RELEASE_1.13.0.md
+++ b/Documentation/PRODUCTION_RELEASE_1.13.0.md
@@ -6,6 +6,8 @@ Joe approved promotion after the [Dev qualification](DEV_ROLLOUT_2026-09-06.md).
 Release source: `576a58808702429ee858f5930edd4d1fb80049b0`, promoted from `dev` to
 `master` by fast-forward. Both version manifests and the changelog identify 1.13.0.
 Later documentation commits do not change the deployed image.
+The production branch was subsequently renamed from `master` to `main` on 2026-09-06;
+the branch names below record the release as it happened.
 
 ```text
 jdcb4/podcast-ad-remover:1.13.0

--- a/Documentation/PROJECT_INDEX.md
+++ b/Documentation/PROJECT_INDEX.md
@@ -51,7 +51,7 @@ docker compose up -d --build
 
 `npm run verify` is the normal pre-change completion check. `npm run verify:docker` adds a local Docker image build and should be used before release tagging or publishing.
 
-Normal work integrates into `dev`. Dev images publish as `:dev` and `:dev-<git-sha>`; production promotion to `master`, SemVer, and `latest` requires explicit approval.
+Normal work integrates into `dev`, the GitHub default branch. Dev images publish as `:dev` and `:dev-<git-sha>`; production promotion to `main`, SemVer, and `latest` requires explicit approval. Keep only these two long-lived branches plus active, unmerged feature work.
 
 ## Documentation Map
 
@@ -60,6 +60,7 @@ Normal work integrates into `dev`. Dev images publish as `:dev` and `:dev-<git-s
 - `Documentation/Deployment.md`: Docker and Docker Compose deployment.
 - `Documentation/Environment_Variables.md`: environment configuration.
 - `Documentation/VERSIONING.md`: version bump and Docker tag rules.
+- `Documentation/GIT_WORKFLOW.md`: protected branches, worktrees, safe cleanup and older-clone migration.
 - `Documentation/VERIFICATION.md`: checks to run before merging or releasing.
 - `Documentation/CHANGELOG.md`: release notes.
 - `Documentation/AUDIT_STATUS.md`: current assessment status and links to historical audit evidence.

--- a/Documentation/VERIFICATION.md
+++ b/Documentation/VERIFICATION.md
@@ -120,7 +120,7 @@ The helper takes an integrity-checked SQLite online backup, including committed 
 
 ## Branch And Pull Request Check
 
-GitHub Actions runs `npm run verify` on pull requests and pushes to `dev` and `master`. Pull requests normally target `dev`; `master` is reserved for explicitly approved production promotions. The workflow sets `DATA_DIR` to a temporary Linux runner path so tests do not depend on `/data` being writable.
+GitHub Actions runs `npm run verify` on pull requests and pushes to `dev` and `main`. The `verify` job from GitHub Actions is a required check for both branches. Pull requests normally target `dev`; `main` is reserved for explicitly approved production promotions. The workflow sets `DATA_DIR` to a temporary Linux runner path so tests do not depend on `/data` being writable. See [Git workflow](GIT_WORKFLOW.md) for branch rules and maintenance.
 
 ## Dev Image Check And Publish
 
@@ -145,7 +145,7 @@ The rolling tag is convenient for the Dev environment; the SHA tag records the e
 
 ## Release Publish Check
 
-Only run the production release path after the tested Dev revision has received explicit promotion approval and has been merged into `master`. The release helper requires a clean `master` checkout, reads the version from `package.json`, validates that it is `MAJOR.MINOR.PATCH`, runs verification, and builds two tags:
+Only run the production release path after the tested Dev revision has received explicit promotion approval and has been merged into `main`. The release helper requires a clean `main` checkout, reads the version from `package.json`, validates that it is `MAJOR.MINOR.PATCH`, runs verification, and builds two tags:
 
 ```bash
 npm run docker:build

--- a/Documentation/VERSIONING.md
+++ b/Documentation/VERSIONING.md
@@ -19,9 +19,10 @@ jdcb4/podcast-ad-remover:latest
 
 ## Branches And Image Channels
 
-- `dev` is the primary integration branch for completed development work.
-- `master` is the production branch and must change only during an explicitly approved release promotion.
+- `dev` is the GitHub default and primary integration branch for completed development work.
+- `main` is the production branch and receives application changes only during an explicitly approved release promotion.
 - Normal feature and fix branches start from and merge back into `dev`.
+- Both long-lived branches require the GitHub Actions `verify` check. See [Git workflow](GIT_WORKFLOW.md) for protection, worktrees and cleanup.
 
 Dev images stay in the same Docker Hub repository but use non-release tags:
 
@@ -68,12 +69,12 @@ npm run verify:docker
 
 Do not continue until Joe explicitly approves production promotion of the tested candidate.
 
-6. Merge the approved `dev` revision into `master` without adding unrelated changes.
-7. From a clean `master` checkout, repeat required release verification and publish:
+6. Confirm the approved `dev` revision has a successful GitHub Actions `verify` check. Fast-forward `main` to that exact revision without adding unrelated changes; do not squash or rebase a production promotion. If `dev` has advanced since qualification, use the recorded approved commit, not its newer tip. Stop and reconcile any divergence before publishing.
+7. From a clean `main` checkout, repeat required release verification and publish:
 
 ```bash
 npm run docker:publish
 ```
 
 This builds and pushes `jdcb4/podcast-ad-remover:<version>` and `jdcb4/podcast-ad-remover:latest`.
-The release helper refuses to run outside a clean `master` checkout.
+The release helper refuses to run outside a clean `main` checkout. Return the primary working checkout to `dev` after completing the release.

--- a/Documentation/unraid/podcast-ad-remover.xml
+++ b/Documentation/unraid/podcast-ad-remover.xml
@@ -20,8 +20,8 @@ Features:&#xD;
   </Overview>
   <Category>MediaApp:Audio</Category>
   <WebUI>http://[IP]:[PORT:8000]/</WebUI>
-  <TemplateURL>https://raw.githubusercontent.com/jdcb4/podcast-ad-remover/master/Documentation/unraid/podcast-ad-remover.xml</TemplateURL>
-  <Icon>https://raw.githubusercontent.com/jdcb4/podcast-ad-remover/master/app/web/static/favicon.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/jdcb4/podcast-ad-remover/main/Documentation/unraid/podcast-ad-remover.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/jdcb4/podcast-ad-remover/main/app/web/static/favicon.png</Icon>
   <ExtraParams/>
   <PostArgs/>
   <CPUset/>

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ npm run docker:experimental:arm64 -- --push
 
 `linux/amd64` remains the primary release target. The ARM64 experimental image skips Piper because its phonemizer dependency is not currently available as a simple Linux arm64 wheel. Podcast download, local transcription, ad detection, cutting, feeds, and the web UI remain the target feature set. Spoken summaries and title intros can still be tested on no-Piper images by selecting Gemini TTS and configuring a Gemini API key.
 
-Production promotion from `dev` to `master` requires explicit approval. Release publishing then runs from a clean `master` checkout and tags both the version and `latest`:
+Production promotion from `dev` to `main` requires explicit approval. Release publishing then runs from a clean `main` checkout and tags both the version and `latest`:
 
 ```bash
 npm run docker:publish
@@ -257,6 +257,7 @@ npm run docker:publish
 - [Environment Variables](Documentation/Environment_Variables.md)
 - [Verification](Documentation/VERIFICATION.md)
 - [Versioning](Documentation/VERSIONING.md)
+- [Git workflow and branch cleanup](Documentation/GIT_WORKFLOW.md)
 - [Changelog](Documentation/CHANGELOG.md)
 - [Decisions](Documentation/DECISIONS.md)
 - [Resource Audit](Documentation/RESOURCE_AUDIT.md)

--- a/scripts/publish_docker.py
+++ b/scripts/publish_docker.py
@@ -16,7 +16,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_REPOSITORY = "jdcb4/podcast-ad-remover"
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
-PRODUCTION_BRANCH = "master"
+PRODUCTION_BRANCH = "main"
 
 
 def executable(name: str) -> str:

--- a/tests/test_docker_publish_scripts.py
+++ b/tests/test_docker_publish_scripts.py
@@ -52,14 +52,19 @@ def test_validate_dev_checkout_requires_clean_tree():
         validate_dev_checkout("dev", False)
 
 
-def test_validate_release_checkout_requires_master_branch():
-    with pytest.raises(SystemExit, match="must be built from branch 'master'"):
-        validate_release_checkout("dev", True)
+@pytest.mark.parametrize("branch", ["dev", "master", "codex/test", ""])
+def test_validate_release_checkout_requires_main_branch(branch):
+    with pytest.raises(SystemExit, match="must be built from branch 'main'"):
+        validate_release_checkout(branch, True)
+
+
+def test_validate_release_checkout_accepts_clean_main():
+    validate_release_checkout("main", True)
 
 
 def test_validate_release_checkout_requires_clean_tree():
     with pytest.raises(SystemExit, match="clean committed checkout"):
-        validate_release_checkout("master", False)
+        validate_release_checkout("main", False)
 
 
 def test_package_exposes_separate_dev_build_and_publish_commands():


### PR DESCRIPTION
Production used `master` while the existing protection rule targeted a nonexistent `main`, and merged branches accumulated locally. Make `dev` the GitHub default, rename production to `main`, and align CI, release guards, instructions and Unraid raw-file URLs with the requested workflow.

Preserve the concluded local-LLM experiment under an annotated archive tag, remove proven merged branches, retain open contributor PRs targeting `dev`, and document safe worktree cleanup and older-clone migration. Require the existing GitHub Actions `verify` check on both long-lived branches and enable merged-PR branch cleanup. This repository-maintenance change does not publish or deploy a new application release.

Validation: `npm run verify` passed all 318 tests, Python syntax, CSS build, npm audit and pip-audit. The release guard accepts clean `main` and rejects the previous branch name, development/feature branches, detached HEAD and dirty production checkouts. A complete Git bundle and original repository settings were verified before cleanup.