### PR TITLE
Accept validated artwork served as generic binary content

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept valid podcast artwork served with the generic `application/octet-stream` content type. Keep download limits and image decoding checks, and preserve cached artwork when the response is not a valid image.
 - Reduce badged podcast artwork to JPEG at quality 82, with a maximum edge of 1400px, contributed by [Paul McManus (@pmacca) in PR #22](https://github.com/jdcb4/podcast-ad-remover/pull/22). Keep cached PNG feed URLs working and retain the old image until the replacement path commits successfully. Save global subscription settings once after upgrading to regenerate existing artwork and feeds.
 - Add administrator-managed unified-feed preferences for its name, description, podcast-name episode-title prefix, and external artwork URL, contributed by [Paul McManus (@pmacca) in PR #20](https://github.com/jdcb4/podcast-ad-remover/pull/20). Preserve the existing address and defaults, validate RSS-safe metadata, include authentication in the settings-page feed address, and explain unavailable HTTP artwork previews.
 - Make `dev` the GitHub default and rename production `master` to `main`; align CI, release guards and Unraid template URLs. Require verification on both long-lived branches, clean up merged branches, and retain the abandoned local-LLM experiment under an archive tag.

--- a/app/core/artwork.py
+++ b/app/core/artwork.py
@@ -60,8 +60,11 @@ class ArtworkWatermarker:
                     str(response.url),
                     allow_private=settings.ALLOW_PRIVATE_FEEDS,
                 )
-                content_type = response.headers.get("content-type", "").split(";", 1)[0].lower()
-                if content_type and not content_type.startswith("image/"):
+                content_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+                # Some podcast CDNs serve valid images with a generic binary MIME
+                # type. Reconcile still decodes and validates the bounded bytes
+                # before publishing any replacement artwork.
+                if content_type and content_type != "application/octet-stream" and not content_type.startswith("image/"):
                     raise ValueError("Podcast artwork response is not an image")
                 content_length = int(response.headers.get("content-length") or 0)
                 if content_length > MAX_ARTWORK_BYTES:

--- a/tests/test_artwork_watermark.py
+++ b/tests/test_artwork_watermark.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+import httpx
 from PIL import Image
 
 from app.core.artwork import BADGE_PATH, ArtworkWatermarker, effective_artwork_url
@@ -17,6 +18,51 @@ from app.web.router import serve_watermarked_artwork
 
 
 CACHE_CONTROL = "public, max-age=31536000, immutable"
+
+
+@pytest.mark.parametrize("content_type,valid_image,accepted", [
+    ("Application/Octet-Stream ; charset=binary", True, True),
+    ("application/octet-stream", False, False),
+    ("text/html", True, False),
+])
+def test_artwork_download_validates_generic_binary_responses(
+    isolated_data_dir, monkeypatch, content_type, valid_image, accepted,
+):
+    init_db()
+    with get_db_connection() as conn:
+        conn.execute("UPDATE app_settings SET default_watermark_artwork=1 WHERE id=1")
+        conn.commit()
+    repo = SubscriptionRepository()
+    sub = repo.create(SubscriptionCreate(feed_url="https://example.com/feed.xml"),
+                      "Binary artwork", "binary-artwork", image_url="https://example.com/cover")
+    legacy = Path(settings.ARTWORK_DIR) / f"{sub.id}.png"
+    legacy.parent.mkdir(parents=True, exist_ok=True)
+    legacy.write_bytes(_image_bytes())
+    with get_db_connection() as conn:
+        conn.execute("UPDATE subscriptions SET watermarked_image_path=?,watermarked_image_hash=? WHERE id=?",
+                     (str(legacy), "legacy", sub.id))
+        conn.commit()
+    source = io.BytesIO()
+    Image.new("RGB", (1534, 1534), (180, 40, 80)).save(source, format="JPEG")
+    body = source.getvalue() if valid_image else b"<html>Temporarily unavailable</html>"
+    transport = httpx.MockTransport(lambda request: httpx.Response(
+        200, headers={"content-type": content_type, "content-length": str(len(body))}, content=body,
+    ))
+    client_type = httpx.Client
+    monkeypatch.setattr(settings, "ALLOW_PRIVATE_FEEDS", True)
+    monkeypatch.setattr("app.core.artwork.httpx.Client", lambda **kwargs: client_type(transport=transport, **kwargs))
+    if accepted:
+        output = ArtworkWatermarker().reconcile(sub.id)
+        with Image.open(output) as image:
+            assert image.format == "JPEG" and image.size == (1400, 1400)
+        assert not legacy.exists()
+        assert repo.get_by_id(sub.id).watermarked_image_path == output
+    else:
+        with pytest.raises(ValueError, match="not an image|could not be decoded safely"):
+            ArtworkWatermarker().reconcile(sub.id)
+        assert legacy.is_file()
+        assert repo.get_by_id(sub.id).watermarked_image_path == str(legacy)
+        assert not (Path(settings.ARTWORK_DIR) / f"{sub.id}.jpg").exists()
 
 
 def _image_bytes(size=(600, 600), color=(180, 40, 80)):


### PR DESCRIPTION
A podcast artwork CDN returns a valid JPEG with `application/octet-stream`. Dev qualification found that the existing MIME check rejects it before decoding, so the subscription cannot generate its ad-free cover.

Allow that generic binary MIME type and normalize header whitespace. Download size limits, URL/redirect protections, and Pillow decoding/dimension checks remain in place. Invalid binary content and explicitly non-image content keep the existing cached artwork.

Validation: `npm run verify` passes (448 tests; five Windows-only skips), including valid binary JPEG, invalid binary content, and rejected HTML MIME regressions. The other three live Dev artwork sources converted successfully. The exact merged build will be redeployed and checked against the affected CDN before production readiness is assessed.
