### PR TITLE
Retain API v1 for the timestamp update

### DIFF
--- a/Documentation/DECISIONS.md
+++ b/Documentation/DECISIONS.md
@@ -2,6 +2,16 @@
 
 This is a lightweight decision log. Keep entries short, dated, and focused on choices that future maintainers may otherwise revisit.
 
+## 2026-09-10: Retain API v1 for the UTC timestamp update
+
+The maintainer accepted the timestamp parser compatibility risk given the limited known API
+usage. Keep `/api/v1` and the new UTC timestamp representation; do not introduce an API v2
+or duplicate legacy timestamp fields for this change. Target the next minor application
+release, 1.14.0, as an explicit exception to the usual major-version rule for incompatible
+API changes. Preserve the warning in [API.md](API.md#timestamp-formats) and the release notes
+so clients using strict parsers can update. Historical timezone provenance remains unchanged.
+This decision accepts the compatibility tradeoff; production promotion remains a separate step.
+
 ## 2026-09-06: Keep dev and main as the only long-lived branches
 
 Joe requested `dev` as the working/default branch and `main` as production. Rename `master` to

--- a/Documentation/VERSIONING.md
+++ b/Documentation/VERSIONING.md
@@ -41,6 +41,12 @@ jdcb4/podcast-ad-remover:dev-<git-sha>
 
 Because existing installs may have many downloaded podcasts, database and `/data` compatibility should be treated as release-critical.
 
+For the next release (1.14.0), the maintainer has explicitly accepted the timestamp
+value-format change within `/api/v1` as a scoped exception to the major-version rule.
+Retain the new UTC representation and document the parser impact in the release notes.
+See the 2026-09-10 decision in [DECISIONS.md](DECISIONS.md). This does not change the
+versioning rules for other incompatible changes or authorize production promotion.
+
 ## Release Checklist
 
 During normal development, publish and test clean committed Dev builds as needed:


### PR DESCRIPTION
Record the maintainer's acceptance of the timestamp parser compatibility risk within `/api/v1`, keeping the new UTC representation. Set 1.14.0 as the next release target under a scoped exception to the usual major-version rule, with the parser impact retained in the API documentation and release notes.

This changes documentation only. Application code, package versions and deployments are unchanged.

Validation: `npm run verify` passed (448 tests, five platform-specific skips, syntax check, CSS build and dependency audits). An initial Windows browser-test subprocess timed out; both browser cases passed on the focused rerun and the complete suite passed afterward. Required GitHub verification must pass before merging.
