### PR TITLE
feat: make download redirect limit configurable

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -37,6 +37,7 @@ class Settings(BaseSettings):
     LOG_BACKUP_COUNT: int = 5
     MAX_FEED_BYTES: int = 10 * 1024 * 1024  # 10 MB
     MAX_DOWNLOAD_BYTES: int = 1500 * 1024 * 1024  # 1.5 GB
+    MAX_DOWNLOAD_REDIRECTS: int = Field(5, ge=0, le=50)
     MIN_FREE_SPACE_BYTES: int = 1024 * 1024 * 1024  # 1 GB
     FFMPEG_TIMEOUT_SECONDS: int = 7200  # 2 hours per FFmpeg operation
     ALLOW_PRIVATE_FEEDS: bool = True

--- a/app/core/http_downloads.py
+++ b/app/core/http_downloads.py
@@ -14,7 +14,21 @@ import httpx
 from app.core.config import settings
 from app.core.url_utils import validate_http_url
 
-MAX_REDIRECTS = 5
+def max_download_redirects() -> int:
+    """Return the configured download redirect cap."""
+    value = getattr(settings, 'MAX_DOWNLOAD_REDIRECTS', 5)
+    try:
+        from app.core.utils import get_global_settings
+
+        global_settings = get_global_settings()
+        value = global_settings.get('download_max_redirects', value)
+    except Exception:
+        pass
+
+    try:
+        return max(0, min(50, int(value)))
+    except (TypeError, ValueError):
+        return 5
 
 
 def request_target(url: str):
@@ -33,27 +47,29 @@ def request_target(url: str):
 
 @contextmanager
 def stream_get(client, url: str, *, timeout=30.0):
-    for hop in range(MAX_REDIRECTS + 1):
+    redirect_limit = max_download_redirects()
+    for hop in range(redirect_limit + 1):
         target, headers, extensions = request_target(url)
         with client.stream('GET', target, headers=headers, extensions=extensions, follow_redirects=False, timeout=timeout) as response:
             if not response.is_redirect:
                 yield response
                 return
             location = response.headers.get('location')
-            if not location or hop == MAX_REDIRECTS:
+            if not location or hop == redirect_limit:
                 raise ValueError('Invalid redirect or too many redirects')
             url = urljoin(url, location)
 
 
 @asynccontextmanager
 async def async_stream_get(client, url: str, *, timeout=300.0):
-    for hop in range(MAX_REDIRECTS + 1):
+    redirect_limit = max_download_redirects()
+    for hop in range(redirect_limit + 1):
         target, headers, extensions = await asyncio.to_thread(request_target, url)
         async with client.stream('GET', target, headers=headers, extensions=extensions, follow_redirects=False, timeout=timeout) as response:
             if not response.is_redirect:
                 yield response
                 return
             location = response.headers.get('location')
-            if not location or hop == MAX_REDIRECTS:
+            if not location or hop == redirect_limit:
                 raise ValueError('Invalid redirect or too many redirects')
             url = urljoin(url, location)

--- a/app/infra/database.py
+++ b/app/infra/database.py
@@ -428,6 +428,7 @@ def init_db():
         ai_model_cascade TEXT DEFAULT '["gemini-3.5-flash", "gemini-3-flash", "gemini-3.1-flash-lite", "gemini-2.5-flash", "gemini-2.5-flash-lite"]',
         piper_model TEXT DEFAULT 'en_GB-cori-high.onnx',
         concurrent_downloads INTEGER DEFAULT 2,
+        download_max_redirects INTEGER DEFAULT 5,
         retention_days INTEGER DEFAULT 30,
         check_interval_minutes INTEGER DEFAULT 60,
         daily_download_limit INTEGER DEFAULT 0,
@@ -604,6 +605,7 @@ def init_db():
         "ALTER TABLE subscriptions ADD COLUMN manual_retention_days INTEGER DEFAULT 14",
         "ALTER TABLE subscriptions ADD COLUMN retention_limit INTEGER DEFAULT 1",
         "ALTER TABLE app_settings ADD COLUMN check_interval_minutes INTEGER DEFAULT 60",
+        "ALTER TABLE app_settings ADD COLUMN download_max_redirects INTEGER DEFAULT 5",
         
         # Global Subscription Defaults
         "ALTER TABLE app_settings ADD COLUMN default_remove_ads INTEGER DEFAULT 1",

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -507,6 +507,7 @@ async def create_setup_admin_user(
 async def update_system_settings(
     request: Request,
     concurrent_downloads: int = Form(2),
+    download_max_redirects: int = Form(5),
     retention_days: int = Form(30),
     check_interval_minutes: int = Form(60),
     whisper_cpu_threads: int = Form(0),
@@ -598,12 +599,14 @@ async def update_system_settings(
         # Update settings
         whisper_cpu_threads = max(0, min(64, whisper_cpu_threads or 0))
         ffmpeg_threads = max(0, min(64, ffmpeg_threads or 0))
+        download_max_redirects = max(0, min(50, download_max_redirects or 0))
         ai_api_default_requests_per_minute = max(1, min(10000, ai_api_default_requests_per_minute or 60))
         ai_api_default_requests_per_day = max(1, min(1000000, ai_api_default_requests_per_day or 1000))
         ai_api_unauth_requests_per_minute = max(1, min(1000, ai_api_unauth_requests_per_minute or 10))
 
         conn.execute("""
             UPDATE app_settings SET concurrent_downloads = ?,
+                download_max_redirects = ?,
                 retention_days = ?,
                 check_interval_minutes = ?,
                 whisper_cpu_threads = ?,
@@ -623,7 +626,7 @@ async def update_system_settings(
                 whitelist_mode = ?,
                 updated_at = CURRENT_TIMESTAMP
             WHERE id = 1
-        """, (concurrent_downloads, retention_days, check_interval_minutes,
+        """, (concurrent_downloads, download_max_redirects, retention_days, check_interval_minutes,
               whisper_cpu_threads, ffmpeg_threads, 1 if unload_whisper_after_job else 0,
               1 if ai_api_enabled else 0,
               ai_api_default_requests_per_minute,

--- a/app/web/templates/admin/system.html
+++ b/app/web/templates/admin/system.html
@@ -111,6 +111,13 @@
             </div>
 
             <div>
+                <label class="block text-sm font-medium text-text-secondary mb-2">Download Redirect Limit</label>
+                <input type="number" name="download_max_redirects" value="{{ settings.download_max_redirects or 5 }}"
+                    min="0" max="50" class="input">
+                <p class="text-xs text-text-muted mt-1">Maximum HTTP redirects to follow for episode downloads.</p>
+            </div>
+
+            <div>
                 <label class="block text-sm font-medium text-text-secondary mb-2">Retention Policy</label>
                 <div class="flex items-center gap-2">
                     <input type="number" name="retention_days" value="{{ settings.retention_days or 30 }}" min="1"

--- a/tests/test_download_redirects.py
+++ b/tests/test_download_redirects.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.core.config import settings
 from app.core.http_downloads import stream_get, async_stream_get
+from app.infra.database import get_db_connection, init_db
 
 
 @pytest.fixture
@@ -41,3 +42,39 @@ async def test_async_download_pins_dns_and_checks_each_redirect(restricted):
             async with async_stream_get(client, 'https://public.test/audio'):
                 pytest.fail('Private redirect accepted')
     assert len(requests) == 1
+
+
+def test_download_redirect_limit_comes_from_system_settings(isolated_data_dir):
+    init_db()
+    with get_db_connection() as conn:
+        conn.execute("UPDATE app_settings SET download_max_redirects = 7 WHERE id = 1")
+        conn.commit()
+
+    seen = []
+
+    def handler(request):
+        seen.append(str(request.url))
+        if len(seen) <= 6:
+            return httpx.Response(302, headers={"Location": f"https://example.test/hop-{len(seen)}"})
+        return httpx.Response(200, headers={"Content-Type": "audio/mpeg"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with stream_get(client, "https://example.test/start") as response:
+            assert response.status_code == 200
+
+    assert len(seen) == 7
+
+
+def test_download_redirect_limit_still_rejects_excessive_redirects(isolated_data_dir):
+    init_db()
+    with get_db_connection() as conn:
+        conn.execute("UPDATE app_settings SET download_max_redirects = 2 WHERE id = 1")
+        conn.commit()
+
+    def handler(request):
+        return httpx.Response(302, headers={"Location": "https://example.test/next"})
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ValueError, match="too many redirects"):
+            with stream_get(client, "https://example.test/start"):
+                pytest.fail("redirect chain should have been rejected")

--- a/tests/test_startup_security.py
+++ b/tests/test_startup_security.py
@@ -130,6 +130,44 @@ async def test_system_settings_refuse_standalone_feed_auth_without_credentials(i
     assert row["enable_feed_auth"] == 0
     assert row["feed_auth_username"] is None
     assert row["feed_auth_password"] is None
+
+
+@pytest.mark.asyncio
+async def test_system_settings_update_saves_download_redirect_limit(isolated_data_dir, monkeypatch):
+    init_db()
+    monkeypatch.setattr(settings, "SESSION_SECRET_KEY", "test-secret-that-is-not-the-default")
+
+    response = await web_router.update_system_settings(
+        request=object(),
+        concurrent_downloads=2,
+        download_max_redirects=12,
+        retention_days=30,
+        check_interval_minutes=60,
+        whisper_cpu_threads=0,
+        ffmpeg_threads=0,
+        unload_whisper_after_job=False,
+        ai_api_enabled=False,
+        ai_api_default_requests_per_minute=60,
+        ai_api_default_requests_per_day=1000,
+        ai_api_unauth_requests_per_minute=10,
+        app_external_url=None,
+        auth_enabled=False,
+        ip_allowlist=None,
+        enable_feed_auth=False,
+        feed_auth_username=None,
+        feed_auth_password=None,
+        public_subscribe_page_enabled=False,
+        whitelist_mode=None,
+        redirect_to=None,
+        admin_user=object(),
+    )
+
+    assert response.status_code == 303
+    with get_db_connection() as conn:
+        row = conn.execute("SELECT download_max_redirects FROM app_settings WHERE id = 1").fetchone()
+    assert row["download_max_redirects"] == 12
+
+
 @pytest.mark.parametrize("secret", ["", " ", "replace-with-a-long-random-secret", "change-me", "changeme"])
 def test_documented_placeholders_are_rejected(monkeypatch, secret):
     from app.core.config import is_default_session_secret, settings


### PR DESCRIPTION
Add a System Settings field and database-backed setting for the maximum number of HTTP redirects followed when downloading episodes. This lets redirect-heavy podcast feeds be processed without changing code while keeping a bounded cap.