### PR TITLE
Use wooden notes as the default removal sounds

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Select Wooden notes as the default beginning, ending and middle-removal sounds; migrate the former Soft chime defaults without changing enable switches or other selected styles.
+
+
 - Update Gemini, OpenAI, Anthropic and OpenRouter default cascades to the requested model lists; share runtime/UI defaults and migrate recognized old defaults once without replacing custom selections. Gemini speech defaults stay unchanged.
 - Add opt-in global removal tones with separate beginning, middle and ending switches and sound selections. Ship six previewable original sound sets as tiny WAV files; insert cues only at removed content, without runtime synthesis or TTS dependencies.
 

--- a/Documentation/Environment_Variables.md
+++ b/Documentation/Environment_Variables.md
@@ -154,7 +154,7 @@ new budget. Authentication/billing failures and exhausted budgets require interv
 ## Removal warning tones
 
 Global Subscription Settings provides independent on/off switches and sound choices for start,
-middle and end removals. All switches default off; the initial sound choice is Soft chime.
+middle and end removals. All switches default off; the initial sound choice is Wooden notes.
 `warning_tone_start`, `warning_tone_middle`, and `warning_tone_end` control insertion;
 `warning_tone_start_style`, `warning_tone_middle_style`, and `warning_tone_end_style` select
 `soft`, `warm`, `clear`, `bell`, `sonar`, or `wooden` independently.

--- a/Documentation/WARNING_TONES.md
+++ b/Documentation/WARNING_TONES.md
@@ -2,7 +2,7 @@
 
 Use **Podcast Preferences > Global Subscription Settings > Removal Warning Tones** to enable
 start, middle, or end cues independently, and preview/select a sound for each position.
-All switches start off. Soft chime is the initial selection; styles can be mixed.
+All switches start off. Wooden notes is the initial selection; styles can be mixed.
 
 - A beginning cue plays only when source content was removed before the first retained audio.
 - An ending cue plays only when source content was removed after the last retained audio.
@@ -52,3 +52,5 @@ database readable. To restore exact previous settings, use the pre-migration bac
 [Recovery](RECOVERY.md); do not delete or reset `/data`. Model-default migration
 `20260913_0017_model_defaults` changes only known prior defaults, once; customized model lists and
 already frozen Complete Timeline job snapshots remain unchanged.
+
+Migration `20260913_0019_wooden_tone_default` changes the former Soft chime defaults to Wooden notes once, preserving other selected styles and all enable switches. The same pre-migration backup/rollback procedure applies.

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -147,7 +147,7 @@ class AudioProcessor:
         if keep_segments and any(cues.get(position) for position in ('start', 'middle', 'end')):
             from app.core.warning_tones import tone_path
             for position in ('start', 'middle', 'end'):
-                tone_inputs.extend(['-i', str(tone_path(cues.get(f'{position}_style', 'soft'), position))])
+                tone_inputs.extend(['-i', str(tone_path(cues.get(f'{position}_style', 'wooden'), position))])
 
         def add_tone(kind):
             label = f'tone{len(concat_inputs)}'

--- a/app/core/processor.py
+++ b/app/core/processor.py
@@ -1007,7 +1007,7 @@ class Processor:
             tone_options = {position: bool(global_settings.get(f'warning_tone_{position}'))
                             for position in ('start', 'middle', 'end')}
             for position in ('start', 'middle', 'end'):
-                tone_options[f'{position}_style'] = global_settings.get(f'warning_tone_{position}_style') or 'soft'
+                tone_options[f'{position}_style'] = global_settings.get(f'warning_tone_{position}_style') or 'wooden'
             audio_options = {'warning_tones': tone_options} if any(
                 tone_options[position] for position in ('start', 'middle', 'end')) else {}
 

--- a/app/infra/database.py
+++ b/app/infra/database.py
@@ -362,6 +362,15 @@ FORMAL_MIGRATIONS = [
         ],
     ),
 
+    (
+        "20260913_0019_wooden_tone_default",
+        [
+            "UPDATE app_settings SET warning_tone_start_style = 'wooden' WHERE warning_tone_start_style = 'soft'",
+            "UPDATE app_settings SET warning_tone_middle_style = 'wooden' WHERE warning_tone_middle_style = 'soft'",
+            "UPDATE app_settings SET warning_tone_end_style = 'wooden' WHERE warning_tone_end_style = 'soft'",
+        ],
+    ),
+
 ]
 
 SQLITE_BUSY_TIMEOUT_MS = 30000

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -2022,9 +2022,9 @@ async def update_global_subscription_settings(
     warning_tone_start: bool = Form(False),
     warning_tone_middle: bool = Form(False),
     warning_tone_end: bool = Form(False),
-    warning_tone_start_style: str = Form("soft"),
-    warning_tone_middle_style: str = Form("soft"),
-    warning_tone_end_style: str = Form("soft"),
+    warning_tone_start_style: str = Form("wooden"),
+    warning_tone_middle_style: str = Form("wooden"),
+    warning_tone_end_style: str = Form("wooden"),
     admin_user = Depends(require_admin)
 ):
     if warning_tones_present and any(style not in TONE_STYLES for style in

--- a/app/web/templates/admin/global_subscription_settings.html
+++ b/app/web/templates/admin/global_subscription_settings.html
@@ -186,7 +186,7 @@
             <div class="p-4 rounded-xl border border-white/[0.08] space-y-3 min-w-0">
                 <label class="flex items-center gap-3" id="{{ key }}-{{ position }}-label">
                     <input type="radio" name="warning_tone_{{ position }}_style" value="{{ key }}"
-                        {% if (settings['warning_tone_' ~ position ~ '_style'] or 'soft') == key %}checked{% endif %}>
+                        {% if (settings['warning_tone_' ~ position ~ '_style'] or 'wooden') == key %}checked{% endif %}>
                     <span>{{ style.label }}</span>
                 </label>
                 <audio controls preload="none" aria-labelledby="{{ key }}-{{ position }}-label" class="max-w-full"

--- a/tests/test_warning_tones.py
+++ b/tests/test_warning_tones.py
@@ -24,6 +24,7 @@ def test_model_defaults_upgrade_preserves_custom_settings(isolated_data_dir):
         for provider, column in columns.items():
             assert json.loads(row[column]) == MODEL_DEFAULTS[provider]
         assert all(row[f'warning_tone_{part}'] == 0 for part in ('start', 'middle', 'end'))
+        assert all(row[f'warning_tone_{part}_style'] == 'wooden' for part in ('start', 'middle', 'end'))
         conn.execute("DELETE FROM schema_migrations WHERE version = '20260913_0017_model_defaults'")
         conn.execute("UPDATE app_settings SET openai_model = ?, anthropic_model = 'my-custom-model'", ('["gpt-4o"]',))
         conn.commit()


### PR DESCRIPTION
Set Wooden notes as the default beginning, ending and middle-removal sound. A one-time migration replaces the previous Soft chime defaults while preserving other selected styles and all enable switches. Keep bundled audio and sound alternatives unchanged.

Validation: npm run verify passed (510 tests passed, 5 skipped, CSS build, frontend and Python audits).
