### PR TITLE
Use fixed Wooden notes with enable-only settings

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Simplify removal-tone settings to three enable switches using fixed Wooden notes. Remove in-app sound selection and previews; ignore legacy style values without deleting stored settings.
+
 - Select Wooden notes as the default beginning, ending and middle-removal sounds; migrate the former Soft chime defaults without changing enable switches or other selected styles.
 
 

--- a/Documentation/Environment_Variables.md
+++ b/Documentation/Environment_Variables.md
@@ -153,10 +153,9 @@ new budget. Authentication/billing failures and exhausted budgets require interv
 
 ## Removal warning tones
 
-Global Subscription Settings provides independent on/off switches and sound choices for start,
-middle and end removals. All switches default off; the initial sound choice is Wooden notes.
-`warning_tone_start`, `warning_tone_middle`, and `warning_tone_end` control insertion;
-`warning_tone_start_style`, `warning_tone_middle_style`, and `warning_tone_end_style` select
-`soft`, `warm`, `clear`, `bell`, `sonar`, or `wooden` independently.
+Global Subscription Settings provides independent on/off switches for start, middle and end
+removals. All switches default off and always use the bundled Wooden notes sounds.
+`warning_tone_start`, `warning_tone_middle`, and `warning_tone_end` control insertion.
+Legacy `warning_tone_*_style` columns remain for rollback compatibility but are ignored.
 These global audio settings apply to all podcasts when processing begins, including reprocessing.
 They do not alter existing published files automatically. See [Warning tones](WARNING_TONES.md).

--- a/Documentation/VERIFICATION.md
+++ b/Documentation/VERIFICATION.md
@@ -271,6 +271,6 @@ re-enabling work. A build alone does not validate production data or paid provid
 ## Model defaults and warning tones
 
 `test_warning_tones.py` checks fresh defaults, a one-time upgrade preserving custom model choices,
-settings persistence/validation and older form compatibility. Real FFmpeg fixtures exercise all
+settings persistence, absence of sound selectors/previews, and older form compatibility. Real FFmpeg fixtures exercise all
 combinations of the three tone switches, overlapping cuts, audible cue placement, retained silence,
-edge-free cuts and no-cut output. Previews and processing share the bundled WAV source files.
+edge-free cuts and no-cut output. Processing always uses Wooden notes, including when legacy style values are supplied.

--- a/Documentation/WARNING_TONES.md
+++ b/Documentation/WARNING_TONES.md
@@ -1,8 +1,8 @@
 # Removal warning tones
 
 Use **Podcast Preferences > Global Subscription Settings > Removal Warning Tones** to enable
-start, middle, or end cues independently, and preview/select a sound for each position.
-All switches start off. Wooden notes is the initial selection; styles can be mixed.
+start, middle, or end cues independently. All switches start off.
+Wooden notes is the fixed sound set; the app has no sound selectors or previews.
 
 - A beginning cue plays only when source content was removed before the first retained audio.
 - An ending cue plays only when source content was removed after the last retained audio.
@@ -13,24 +13,15 @@ All switches start off. Wooden notes is the initial selection; styles can be mix
 These settings are global for all podcasts and are read when processing begins. They apply to both
 Legacy and Complete Timeline, including SponsorBlock cuts. Source timestamps and removal statistics
 remain on the original timeline; the published duration includes inserted cues. Existing episodes
-need reprocessing to receive changed sounds.
+need reprocessing to receive changed enable switches.
 
-## Sound choices
+## Fixed sound
 
-| Style | Character | Beginning / ending |
-| --- | --- | --- |
-| Soft chime | Gentle pure tones | Three ascending / descending notes |
-| Warm mellow | Lower, rounded tones | Three ascending / descending notes |
-| Clear signal | Brighter, higher tones | Three ascending / descending notes |
-| Gentle bell | Soft harmonic bell | Two ascending / descending notes |
-| Sonar pair | Smooth pulsing tones | Two ascending / descending notes |
-| Wooden notes | Short, damped harmonic taps | Two ascending / descending notes |
-
-Every style includes one low middle-removal tone. Edge cues last approximately 0.47–0.70 seconds;
-middle cues last 0.25 seconds. Peak amplitude is bounded around -18 dBFS with smoothed attack/release.
-Actual perceived loudness depends on the source podcast and playback volume.
-
-Listen in the settings page or open [the standalone sound gallery](WARNING_TONE_SAMPLES.html).
+Wooden notes uses short, damped harmonic taps: two ascending notes at the beginning,
+two descending notes at the end, and one low note at an interior removal.
+Edge cues last approximately 0.47 seconds and middle cues last 0.25 seconds.
+The standalone [personal audition gallery](WARNING_TONE_SAMPLES.html) retains the original
+alternatives for development reference only; these are not settings in the app.
 
 ## Assets and implementation
 
@@ -54,3 +45,7 @@ database readable. To restore exact previous settings, use the pre-migration bac
 already frozen Complete Timeline job snapshots remain unchanged.
 
 Migration `20260913_0019_wooden_tone_default` changes the former Soft chime defaults to Wooden notes once, preserving other selected styles and all enable switches. The same pre-migration backup/rollback procedure applies.
+
+Sound style columns from the earlier migrations are retained for rollback compatibility,
+but processing and settings updates now ignore them and always use Wooden notes.
+No schema migration is required for this simplification.

--- a/README.md
+++ b/README.md
@@ -278,5 +278,5 @@ MIT License
 ### Optional removal sounds
 
 Global Subscription Settings includes separate beginning, middle and ending removal tones, off by
-default, with six previewable sound sets. Beginning/end cues play only when content was removed at
-that edge. Sounds are bundled WAVs and do not require TTS. See [sound choices and behavior](Documentation/WARNING_TONES.md).
+default, using the fixed Wooden notes sounds. Beginning/end cues play only when content was removed at
+that edge. Sounds are bundled WAVs and do not require TTS. See [sound behavior](Documentation/WARNING_TONES.md).

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -147,7 +147,7 @@ class AudioProcessor:
         if keep_segments and any(cues.get(position) for position in ('start', 'middle', 'end')):
             from app.core.warning_tones import tone_path
             for position in ('start', 'middle', 'end'):
-                tone_inputs.extend(['-i', str(tone_path(cues.get(f'{position}_style', 'wooden'), position))])
+                tone_inputs.extend(['-i', str(tone_path(position))])
 
         def add_tone(kind):
             label = f'tone{len(concat_inputs)}'

--- a/app/core/processor.py
+++ b/app/core/processor.py
@@ -1006,8 +1006,6 @@ class Processor:
             logger.info("Removing ads with FFmpeg...")
             tone_options = {position: bool(global_settings.get(f'warning_tone_{position}'))
                             for position in ('start', 'middle', 'end')}
-            for position in ('start', 'middle', 'end'):
-                tone_options[f'{position}_style'] = global_settings.get(f'warning_tone_{position}_style') or 'wooden'
             audio_options = {'warning_tones': tone_options} if any(
                 tone_options[position] for position in ('start', 'middle', 'end')) else {}
 

--- a/app/core/warning_tones.py
+++ b/app/core/warning_tones.py
@@ -17,10 +17,10 @@ TONE_STYLES = {
 ASSET_DIR = Path(__file__).resolve().parents[1] / "web" / "static" / "audio" / "warning-tones"
 
 
-def tone_path(style: str, kind: str) -> Path:
-    if style not in TONE_STYLES or kind not in ("start", "end", "middle"):
+def tone_path(kind: str) -> Path:
+    if kind not in ("start", "end", "middle"):
         raise ValueError("Unknown warning tone")
-    return ASSET_DIR / f"{style}-{kind}.wav"
+    return ASSET_DIR / f"wooden-{kind}.wav"
 
 
 def generate_assets():
@@ -53,7 +53,7 @@ def generate_assets():
                 if index < len(notes) - 1:
                     samples.extend([0] * int(rate * 0.055))
             samples.extend([0] * int(rate * 0.025))
-            with wave.open(str(tone_path(style, kind)), "wb") as output:
+            with wave.open(str(ASSET_DIR / f"{style}-{kind}.wav"), "wb") as output:
                 output.setparams((1, 2, rate, 0, "NONE", "not compressed"))
                 output.writeframes(struct.pack(f"<{len(samples)}h", *samples))
 

--- a/app/web/router.py
+++ b/app/web/router.py
@@ -1,4 +1,3 @@
-from app.core.warning_tones import TONE_STYLES
 from app.core.model_defaults import MODEL_DEFAULTS
 from app.core.artifacts import artifact_path
 from app.core.permissions import can_manage_subscription as _can_manage_subscription
@@ -1992,7 +1991,6 @@ async def admin_global_subscription_settings(request: Request):
             "user": user,
             "settings": settings_row,
             "active_tab": "global_subs",
-            "tone_styles": TONE_STYLES
         }
     )
 
@@ -2022,14 +2020,8 @@ async def update_global_subscription_settings(
     warning_tone_start: bool = Form(False),
     warning_tone_middle: bool = Form(False),
     warning_tone_end: bool = Form(False),
-    warning_tone_start_style: str = Form("wooden"),
-    warning_tone_middle_style: str = Form("wooden"),
-    warning_tone_end_style: str = Form("wooden"),
     admin_user = Depends(require_admin)
 ):
-    if warning_tones_present and any(style not in TONE_STYLES for style in
-                                     (warning_tone_start_style, warning_tone_middle_style, warning_tone_end_style)):
-        raise HTTPException(400, "Unknown warning tone style")
     from app.core.timeline import WORKFLOWS, threshold
     if default_processing_workflow is not None and default_processing_workflow not in WORKFLOWS:
         raise HTTPException(400, 'Unknown processing workflow')
@@ -2073,10 +2065,8 @@ async def update_global_subscription_settings(
         ))
         if warning_tones_present:
             conn.execute("""UPDATE app_settings SET warning_tone_start = ?, warning_tone_middle = ?,
-                         warning_tone_end = ?, warning_tone_start_style = ?, warning_tone_middle_style = ?,
-                         warning_tone_end_style = ? WHERE id = 1""",
-                         (warning_tone_start, warning_tone_middle, warning_tone_end,
-                          warning_tone_start_style, warning_tone_middle_style, warning_tone_end_style))
+                         warning_tone_end = ? WHERE id = 1""",
+                         (warning_tone_start, warning_tone_middle, warning_tone_end))
         conn.commit()
 
     background_tasks.add_task(_reconcile_artwork_and_feeds)

--- a/app/web/templates/admin/global_subscription_settings.html
+++ b/app/web/templates/admin/global_subscription_settings.html
@@ -168,7 +168,7 @@
         <h3 id="warning-tones-heading" class="font-semibold">Removal Warning Tones</h3>
         <p class="text-sm text-text-secondary">These global switches apply to all podcasts on their next processing run.
             Each tone marks removed content only. Published episodes stay unchanged until reprocessed.
-            Beginning cues rise; ending cues fall to a lower final note. Each middle removal uses one low note.
+            Wooden notes mark each removal. Beginning cues rise; ending cues fall to a lower final note. Each middle removal uses one low note.
             A start cue plays after any spoken title or summary, just before the retained podcast audio.</p>
         <input type="hidden" name="warning_tones_present" value="true">
         {% for position, label in [('start', 'Content removed at start'), ('middle', 'Content removed in the middle'), ('end', 'Content removed at end')] %}
@@ -177,24 +177,6 @@
                 {% if settings['warning_tone_' ~ position] %}checked{% endif %}>
             <span>{{ label }}</span>
         </label>
-        {% endfor %}
-        {% for position, label in [('start', 'Beginning sound'), ('end', 'Ending sound'), ('middle', 'Middle removal sound')] %}
-        <fieldset class="space-y-3">
-            <legend class="font-medium mb-3">{{ label }}</legend>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            {% for key, style in tone_styles.items() %}
-            <div class="p-4 rounded-xl border border-white/[0.08] space-y-3 min-w-0">
-                <label class="flex items-center gap-3" id="{{ key }}-{{ position }}-label">
-                    <input type="radio" name="warning_tone_{{ position }}_style" value="{{ key }}"
-                        {% if (settings['warning_tone_' ~ position ~ '_style'] or 'wooden') == key %}checked{% endif %}>
-                    <span>{{ style.label }}</span>
-                </label>
-                <audio controls preload="none" aria-labelledby="{{ key }}-{{ position }}-label" class="max-w-full"
-                    src="/static/audio/warning-tones/{{ key }}-{{ position }}.wav"></audio>
-            </div>
-            {% endfor %}
-            </div>
-        </fieldset>
         {% endfor %}
     </section>
 

--- a/tests/test_warning_tones.py
+++ b/tests/test_warning_tones.py
@@ -40,21 +40,24 @@ def test_model_defaults_upgrade_preserves_custom_settings(isolated_data_dir):
         assert conn.execute('SELECT openai_model FROM app_settings').fetchone()[0] == 'gpt-4o'
 
 
-def test_tone_settings_save_preview_and_old_form_compatibility(client):
+def test_tone_settings_save_fixed_sound_and_old_form_compatibility(client):
     url = '/admin/global-subscription-settings/update'
     assert client.post(url, data={'warning_tones_present': 'true', 'warning_tone_start': 'true',
                                  'warning_tone_end': 'true', 'warning_tone_start_style': 'warm'},
                        follow_redirects=False).status_code == 303
     page = client.get('/admin/global-subscription-settings')
     assert page.status_code == 200
-    assert page.text.count('<audio controls') == 18
+    assert '<audio controls' not in page.text
+    for position in ('start', 'middle', 'end'):
+        assert f'name="warning_tone_{position}"' in page.text
+        assert f'warning_tone_{position}_style' not in page.text
     assert client.post(url, data={}, follow_redirects=False).status_code == 303
     with get_db_connection() as conn:
         row = conn.execute('SELECT * FROM app_settings').fetchone()
         assert (row['warning_tone_start'], row['warning_tone_middle'], row['warning_tone_end']) == (1, 0, 1)
-        assert row['warning_tone_start_style'] == 'warm'
+        assert row['warning_tone_start_style'] == 'wooden'
     assert client.post(url, data={'warning_tones_present': 'true', 'warning_tone_start_style': '../bad'},
-                       follow_redirects=False).status_code == 400
+                       follow_redirects=False).status_code == 303
     assert client.post(url, data={'warning_tones_present': 'true', 'warning_tone_start_style': 'clear'},
                        follow_redirects=False).status_code == 303
     with get_db_connection() as conn:
@@ -72,7 +75,7 @@ def test_actual_audio_marks_only_removed_intervals(tmp_path, start, middle, end)
     cuts = [{'start': a, 'end': b} for a, b in [(0, 1), (3, 4), (4, 5), (8, 9), (11, 12)]]
     options = dict(start=start, middle=middle, end=end, start_style='soft', middle_style='soft', end_style='soft')
     AudioProcessor.remove_segments(str(source), str(output), cuts, warning_tones=options)
-    edge, low = [AudioProcessor.get_duration(str(tone_path('soft', kind))) for kind in ('start', 'middle')]
+    edge, low = [AudioProcessor.get_duration(str(tone_path(kind))) for kind in ('start', 'middle')]
     assert AudioProcessor.get_duration(str(output)) == pytest.approx(7 + edge * (start + end) + 2 * low * middle, abs=0.1)
     decoded = subprocess.run(['ffmpeg', '-v', 'error', '-i', str(output), '-f', 's16le',
                               '-ac', '1', '-ar', '22050', '-'], capture_output=True, check=True).stdout
@@ -83,7 +86,7 @@ def test_actual_audio_marks_only_removed_intervals(tmp_path, start, middle, end)
     cursor = 0
     for enabled, duration, retained in [(start, edge, 2), (middle, low, 3), (middle, low, 2), (end, edge, 0)]:
         if enabled:
-            assert peak(cursor + .08) > 1000
+            assert peak(cursor + .08) > 100
             cursor += duration
         if retained:
             assert peak(cursor + .5) < 10


### PR DESCRIPTION
Use fixed Wooden notes for all removal cues and expose only the three start/middle/end enable switches. Remove in-app selectors and previews; ignore legacy style settings while retaining their database columns for rollback compatibility. Keep the personal audition gallery separate.

Validation: npm run verify passed (510 tests, 5 skipped), CSS build and frontend/Python dependency audits passed. Audio fixtures cover every enable-switch combination and confirm legacy style inputs cannot change the sound.

Deployment is deferred to the requested one-time idle check at 16:30 Sydney time.
